### PR TITLE
docs: add guideline to sync upstream main before creating branches/PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,7 @@ Tests are in `tests/`. Documentation is in `docs/`. Legacy implementation is arc
 - For behavior changes, update/add tests in the same PR.
 
 ## Commit & Pull Request Guidelines
+- **Before creating branches and submitting PRs, always sync with upstream main branch first.**
 - Follow Conventional Commit style seen in history: `feat:`, `fix:`, `chore:`.
 - Keep commits focused; avoid mixing refactor and behavior change without explanation.
 - PRs should include:


### PR DESCRIPTION
## Summary
- Add important guideline in AGENTS.md: always sync with upstream main branch before creating branches and submitting PRs
- This ensures the codebase is up-to-date and reduces merge conflicts

## Test Plan
- Review the added guideline in AGENTS.md
- Verify it follows the existing documentation style
