### PR TITLE
feat: add Telegram quoted-reply context with compact anchors

### DIFF
--- a/src/bub/channels/telegram.py
+++ b/src/bub/channels/telegram.py
@@ -231,13 +231,11 @@ class TelegramChannel(BaseChannel):
         else:
             lines.append(f"quote: {reply_text}")
 
-        lines.extend(
-            [
-                "rule: if partial=true, recover from ctx by head/tail first; if uncertain ask full quote; no guess",
-                "if_miss: ask user to paste full quote",
-                "</reply_context>",
-            ]
-        )
+        lines.extend([
+            "rule: if partial=true, recover from ctx by head/tail first; if uncertain ask full quote; no guess",
+            "if_miss: ask user to paste full quote",
+            "</reply_context>",
+        ])
 
         return "\n".join(lines)
 

--- a/tests/test_telegram_channel.py
+++ b/tests/test_telegram_channel.py
@@ -25,7 +25,9 @@ def test_compose_inbound_text_appends_reply_context_for_plain_text() -> None:
     assert "from: @alice" in composed
     assert "quote: hello from above" in composed
     assert "partial: false" in composed
-    assert "rule: if partial=true, recover from ctx by head/tail first; if uncertain ask full quote; no guess" in composed
+    assert (
+        "rule: if partial=true, recover from ctx by head/tail first; if uncertain ask full quote; no guess" in composed
+    )
     assert "if_miss: ask user to paste full quote" in composed
 
 


### PR DESCRIPTION
## Problem

Telegram replies were forwarded as plain text only, so the assistant could miss what message was being quoted.

## Fix

- Add structured `reply_context` for Telegram reply messages.
- For short quoted content, pass full `quote`.
- For long quoted content, pass compact anchors: `head`, `tail`, `chars`.
- Keep comma-prefixed command behavior unchanged.

## Fallback behavior

When the quoted message is too far back to be reliably recovered from the current context window, the assistant should ask the user for the full quote instead of guessing.

## Scope

Telegram channel only. No core loop/tape architecture changes.

## Validation

- `uv run pytest -q tests/test_telegram_channel.py tests/test_telegram_filter.py`
- `uv run ruff check src/bub/channels/telegram.py tests/test_telegram_channel.py`
