### PR TITLE
feat: use expandable blockquote for long Telegram messages

### DIFF
--- a/src/bub/channels/telegram.py
+++ b/src/bub/channels/telegram.py
@@ -135,15 +135,15 @@ class TelegramChannel(BaseChannel):
             text = html.escape(raw_content)
             # Convert markdown-style bold/italic/code to HTML tags (basic support)
             # Bold: **text** or __text__
-            text = re.sub(r'\*\*(.+?)\*\*', r'<b>\1</b>', text)
-            text = re.sub(r'__(.+?)__', r'<b>\1</b>', text)
+            text = re.sub(r"\*\*(.+?)\*\*", r"<b>\1</b>", text)
+            text = re.sub(r"__(.+?)__", r"<b>\1</b>", text)
             # Italic: *text* or _text_
-            text = re.sub(r'\*(.+?)\*', r'<i>\1</i>', text)
-            text = re.sub(r'_(.+?)_', r'<i>\1</i>', text)
+            text = re.sub(r"\*(.+?)\*", r"<i>\1</i>", text)
+            text = re.sub(r"_(.+?)_", r"<i>\1</i>", text)
             # Inline code: `text`
-            text = re.sub(r'`(.+?)`', r'<code>\1</code>', text)
+            text = re.sub(r"`(.+?)`", r"<code>\1</code>", text)
             # Newlines to <br>
-            text = text.replace('\n', '<br>')
+            text = text.replace("\n", "<br>")
             text = f"<blockquote expandable>{text}</blockquote>"
             parse_mode = "HTML"
         else:


### PR DESCRIPTION
## Summary

- Use expandable blockquote for messages over 140 chars in Telegram
- Add HTML escape and basic markdown to HTML conversion for long messages
- Short messages still use MarkdownV2 format

## Changes

- Add `html` and `re` imports for HTML escape and regex processing
- Long messages (>140 chars) are wrapped in `<blockquote expandable>` tags
- Convert basic markdown syntax (bold `**text**`, italic `*text*`, code ``text``) to HTML tags
- Replace newlines with `<br>` for proper HTML formatting

This is a rebase of #34 to resolve merge conflicts with the latest main branch.