### PR TITLE
feat: isolate schedule jobstore per session

### DIFF
--- a/src/bub/app/runtime.py
+++ b/src/bub/app/runtime.py
@@ -36,6 +36,7 @@ class SessionRuntime:
     session_id: str
     loop: AgentLoop
     tape: TapeService
+    jobstore_alias: str
 
     async def handle_input(self, text: str) -> LoopResult:
         return await self.loop.handle_input(text)
@@ -60,10 +61,29 @@ class AppRuntime:
         self.bus: MessageBus | None = None
         self.loop: AbstractEventLoop | None = None
         self.registry = ToolRegistry(_normalize_name_set(allowed_tools))
-        job_store = JSONJobStore(settings.resolve_home() / "jobs.json")
-        self.scheduler = BackgroundScheduler(daemon=True, jobstores={"default": job_store})
+        # Scheduler without default jobstore - jobstores are created per-session
+        self.scheduler = BackgroundScheduler(daemon=True)
         self._llm = build_llm(settings, self._store)
         self._sessions: dict[str, SessionRuntime] = {}
+        # Session-specific jobstores
+        self._session_jobstores: dict[str, str] = {}  # session_id -> jobstore_alias
+
+    def _get_jobstore_path(self, session_id: str) -> Path:
+        """Get the jobstore file path for a session."""
+        slug = _session_slug(session_id)
+        return self.settings.resolve_home() / "jobs" / f"{slug}.json"
+
+    def _create_session_jobstore(self, session_id: str) -> str:
+        """Create or get a session-specific jobstore. Returns the jobstore alias."""
+        if session_id in self._session_jobstores:
+            return self._session_jobstores[session_id]
+
+        jobstore_alias = f"session_{_session_slug(session_id)}"
+        jobstore_path = self._get_jobstore_path(session_id)
+        job_store = JSONJobStore(jobstore_path)
+        self.scheduler.add_jobstore(job_store, alias=jobstore_alias)
+        self._session_jobstores[session_id] = jobstore_alias
+        return jobstore_alias
 
     def __enter__(self) -> AppRuntime:
         if not self.scheduler.running:
@@ -97,6 +117,9 @@ class AppRuntime:
         tape = TapeService(self._llm, tape_name, store=self._store)
         tape.ensure_bootstrap_anchor()
 
+        # Create session-specific jobstore
+        jobstore_alias = self._create_session_jobstore(session_id)
+
         registry = self.registry
         register_builtin_tools(
             registry,
@@ -122,7 +145,7 @@ class AppRuntime:
             workspace_system_prompt=self.workspace_prompt,
         )
         loop = AgentLoop(router=router, model_runner=runner, tape=tape)
-        runtime = SessionRuntime(session_id=session_id, loop=loop, tape=tape)
+        runtime = SessionRuntime(session_id=session_id, loop=loop, tape=tape, jobstore_alias=jobstore_alias)
         self._sessions[session_id] = runtime
         return runtime
 

--- a/src/bub/tools/builtin.py
+++ b/src/bub/tools/builtin.py
@@ -179,6 +179,9 @@ def register_builtin_tools(
     from bub.tools.schedule import run_scheduled_reminder
 
     support_scheduling = runtime.scheduler.running
+    # Get session-specific jobstore alias
+    session_runtime = getattr(runtime, "_sessions", {}).get(session_id)
+    jobstore_alias = getattr(session_runtime, "jobstore_alias", None) if session_runtime else None
     register = registry.register
 
     @register(name="bash", short_description="Run shell command", model=BashInput)
@@ -300,6 +303,7 @@ def register_builtin_tools(
                     kwargs={"message": params.message, "session_id": session_id},
                     coalesce=True,
                     max_instances=1,
+                    jobstore=jobstore_alias,
                 )
             except ConflictingIdError as exc:
                 raise RuntimeError(f"job id already exists: {job_id}") from exc
@@ -313,15 +317,15 @@ def register_builtin_tools(
         def schedule_remove(params: ScheduleRemoveInput) -> str:
             """Remove one scheduled job by id."""
             try:
-                runtime.scheduler.remove_job(params.job_id)
+                runtime.scheduler.remove_job(params.job_id, jobstore=jobstore_alias)
             except JobLookupError as exc:
                 raise RuntimeError(f"job not found: {params.job_id}") from exc
             return f"removed: {params.job_id}"
 
         @register(name="schedule.list", short_description="List scheduled jobs", model=EmptyInput)
         def schedule_list(_params: EmptyInput) -> str:
-            """List scheduled jobs for current workspace."""
-            jobs = runtime.scheduler.get_jobs()
+            """List scheduled jobs for current session."""
+            jobs = runtime.scheduler.get_jobs(jobstore=jobstore_alias)
             if not jobs:
                 return "(no scheduled jobs)"
 

--- a/tests/test_tools_builtin.py
+++ b/tests/test_tools_builtin.py
@@ -43,11 +43,24 @@ class _DummyTape:
 
 
 class _DummyRuntime:
-    def __init__(self, settings: Settings, scheduler: BackgroundScheduler) -> None:
+    def __init__(self, settings: Settings, scheduler: BackgroundScheduler, session_id: str = "cli:test") -> None:
         self.settings = settings
         self.scheduler = scheduler
         self._discovered_skills: list[object] = []
         self.bus = None
+        # Simulate session-specific jobstore
+        jobstore_alias = f"session_{session_id.replace(':', '_')}"
+        self._sessions: dict[str, object] = {
+            session_id: type("_DummySession", (), {"jobstore_alias": jobstore_alias})()
+        }
+        # Add a jobstore for this session if not exists
+        if jobstore_alias not in scheduler._jobstores:
+            import tempfile
+
+            from bub.app.jobstore import JSONJobStore
+
+            jobstore_path = Path(tempfile.gettempdir()) / f"bub_test_jobs_{session_id.replace(':', '_')}.json"
+            scheduler.add_jobstore(JSONJobStore(jobstore_path), alias=jobstore_alias)
 
     def discover_skills(self) -> list[object]:
         return list(self._discovered_skills)
@@ -57,15 +70,17 @@ class _DummyRuntime:
         return None
 
 
-def _build_registry(workspace: Path, settings: Settings, scheduler: BackgroundScheduler) -> ToolRegistry:
+def _build_registry(
+    workspace: Path, settings: Settings, scheduler: BackgroundScheduler, session_id: str = "cli:test"
+) -> ToolRegistry:
     registry = ToolRegistry()
-    runtime = _DummyRuntime(settings, scheduler)
+    runtime = _DummyRuntime(settings, scheduler, session_id)
     register_builtin_tools(
         registry,
         workspace=workspace,
         tape=_DummyTape(),  # type: ignore[arg-type]
         runtime=runtime,  # type: ignore[arg-type]
-        session_id="cli:test",
+        session_id=session_id,
     )
     return registry
 
@@ -267,13 +282,15 @@ def test_schedule_remove_missing_job_returns_error(tmp_path: Path, scheduler: Ba
         assert "job not found: missing" in str(exc)
 
 
-def test_schedule_shared_scheduler_across_registries(tmp_path: Path, scheduler: BackgroundScheduler) -> None:
+def test_schedule_isolated_per_session(tmp_path: Path, scheduler: BackgroundScheduler) -> None:
+    """Test that schedule jobs are isolated per session."""
     workspace = tmp_path / "workspace"
     workspace.mkdir()
 
     settings = Settings(_env_file=None, model="openrouter:test")
-    registry_a = _build_registry(workspace, settings, scheduler)
-    registry_b = _build_registry(workspace, settings, scheduler)
+    # Different session IDs should have isolated jobstores
+    registry_a = _build_registry(workspace, settings, scheduler, session_id="cli:session-a")
+    registry_b = _build_registry(workspace, settings, scheduler, session_id="cli:session-b")
 
     add_result = registry_a.execute(
         "schedule.add",
@@ -282,7 +299,13 @@ def test_schedule_shared_scheduler_across_registries(tmp_path: Path, scheduler: 
     matched = re.match(r"^scheduled: (?P<job_id>[a-z0-9-]+) next=.*$", add_result)
     assert matched is not None
 
-    assert matched.group("job_id") in registry_b.execute("schedule.list", kwargs={})
+    # Job from session-a should NOT appear in session-b's list
+    list_b = registry_b.execute("schedule.list", kwargs={})
+    assert "(no scheduled jobs)" in list_b
+
+    # But it should appear in session-a's list
+    list_a = registry_a.execute("schedule.list", kwargs={})
+    assert matched.group("job_id") in list_a
 
 
 def test_skills_list_uses_latest_runtime_skills(tmp_path: Path, scheduler: BackgroundScheduler) -> None:
@@ -292,11 +315,12 @@ def test_skills_list_uses_latest_runtime_skills(tmp_path: Path, scheduler: Backg
         description: str
 
     class _Runtime:
-        def __init__(self, settings: Settings, scheduler: BackgroundScheduler) -> None:
+        def __init__(self, settings: Settings, scheduler: BackgroundScheduler, session_id: str = "cli:test") -> None:
             self.settings = settings
             self.scheduler = scheduler
             self.bus = None
             self._discovered_skills: list[_Skill] = [_Skill(name="alpha", description="first")]
+            self._sessions = {session_id: type("_DummySession", (), {"jobstore_alias": None})()}
 
         def discover_skills(self) -> list[_Skill]:
             return list(self._discovered_skills)


### PR DESCRIPTION
## Summary

Isolate scheduled jobs per session to prevent conflicts between different sessions/users.

## Changes

- Add  field to 
- **Remove default jobstore** - scheduler starts without any jobstore
- Create session-specific jobstore files in 
- Update , , and  tools to use session-specific jobstore
- Jobs from one session are now completely isolated from other sessions

## Benefits

- Different Telegram users/groups can have their own scheduled jobs
- No risk of one session's jobs interfering with another
- Jobs persist per session and can be managed independently
- Cleaner design - no unused default jobstore

## Testing

- Updated  to verify isolation
- All schedule-related tests pass