### PR TITLE
docs: quote json to preserve format

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Common commands:
 ```bash
 BUB_TELEGRAM_ENABLED=true
 BUB_TELEGRAM_TOKEN=123456:token
-BUB_TELEGRAM_ALLOW_FROM=["123456789","your_username"]
+BUB_TELEGRAM_ALLOW_FROM='["123456789","your_username"]'
 uv run bub telegram
 ```
 

--- a/env.example
+++ b/env.example
@@ -56,7 +56,7 @@ LLM_API_KEY=sk-...
 # BUB_TELEGRAM_ENABLED=true
 # BUB_TELEGRAM_TOKEN=123456:telegram-bot-token
 # JSON array recommended:
-# BUB_TELEGRAM_ALLOW_FROM=["123456789","my_username"]
+# BUB_TELEGRAM_ALLOW_FROM='["123456789","my_username"]'
 
 # ---------------------------------------------------------------------------
 # Example minimal OpenRouter setup


### PR DESCRIPTION
shell tends to strip the double quotes, breaks json format with this setting:

```sh
BUB_TELEGRAM_ALLOW_FROM=["123456789","your_username"]
```

And the error message is long and confusing (it looks valid for human):

```log
│ │        field_key = 'telegram_allow_from'                                                                                     │                                                                │
│ │       field_name = 'telegram_allow_from'                                                                                     │                                                                │
│ │      field_value = '[436026689,my_username]'                                                                                 │                                                                │
│ │             self = EnvSettingsSource(env_nested_delimiter=None, env_prefix_len=4)                                            │                                                                │
│ │ value_is_complex = False                                                                                                     │                                                                │
│ ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯                                                                │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
SettingsError: error parsing value for field "telegram_allow_from" from source "EnvSettingsSource"
```

Add single quotes to preserve format:

```sh
BUB_TELEGRAM_ALLOW_FROM='["123456789","your_username"]'
```
