### PR TITLE
security: gate assistant-triggered commands by default

### DIFF
--- a/src/bub/app/runtime.py
+++ b/src/bub/app/runtime.py
@@ -135,6 +135,7 @@ class AppRuntime:
             model_timeout_seconds=self.settings.model_timeout_seconds,
             base_system_prompt=self.settings.system_prompt,
             get_workspace_system_prompt=lambda: read_workspace_agents_prompt(self.workspace),
+            allow_assistant_commands=self.settings.allow_assistant_commands,
         )
         loop = AgentLoop(router=router, model_runner=runner, tape=tape)
         runtime = SessionRuntime(session_id=session_id, loop=loop, tape=tape, model_runner=runner, tool_view=tool_view)

--- a/src/bub/config/settings.py
+++ b/src/bub/config/settings.py
@@ -39,6 +39,10 @@ class Settings(BaseSettings):
 
     proactive_response: bool = False
 
+    # Security: by default, ignore comma-prefixed shell/internal commands emitted by the assistant.
+    # Human comma-prefixed commands are still honored.
+    allow_assistant_commands: bool = False
+
     telegram_enabled: bool = False
     telegram_token: str | None = None
     telegram_allow_from: list[str] = Field(default_factory=list)

--- a/src/bub/core/model_runner.py
+++ b/src/bub/core/model_runner.py
@@ -76,6 +76,7 @@ class ModelRunner:
         self._model_timeout_seconds = model_timeout_seconds
         self._base_system_prompt = base_system_prompt.strip()
         self._get_workspace_system_prompt = get_workspace_system_prompt
+        self._allow_assistant_commands = allow_assistant_commands
         self._expanded_skills: dict[str, str] = {}
 
     def reset_context(self) -> None:
@@ -128,7 +129,7 @@ class ModelRunner:
                 break
 
             self._activate_hints(assistant_text)
-            route = await self._router.route_assistant(assistant_text)
+            route = await self._router.route_assistant(assistant_text, allow_commands=self._allow_assistant_commands)
             self._consume_route(state, route)
             if not route.next_prompt:
                 break

--- a/src/bub/core/router.py
+++ b/src/bub/core/router.py
@@ -109,7 +109,10 @@ class InputRouter:
             exit_requested=False,
         )
 
-    async def route_assistant(self, raw: str) -> AssistantRouteResult:
+    async def route_assistant(self, raw: str, *, allow_commands: bool = False) -> AssistantRouteResult:
+        if not allow_commands:
+            return AssistantRouteResult(visible_text=raw.strip(), next_prompt="", exit_requested=False)
+
         visible_lines: list[str] = []
         command_blocks: list[str] = []
         exit_requested = False


### PR DESCRIPTION
This makes assistant-emitted comma-prefixed commands (shell/internal) opt-in via BUB_ALLOW_ASSISTANT_COMMANDS=true. Human comma-prefixed commands remain unchanged. Motivation: reduce risk of accidental/prompt-injected remote command execution, especially when running via Telegram/Discord channels.