### PR TITLE
fix: remove legacy telegram json parsing from router

### DIFF
--- a/src/bub/core/router.py
+++ b/src/bub/core/router.py
@@ -67,13 +67,7 @@ class InputRouter:
         stripped = raw.strip()
         if not stripped:
             return UserRouteResult(enter_model=False, model_prompt="", immediate_output="", exit_requested=False)
-        try:
-            # For telegram wrapped messages
-            parsed = json.loads(stripped)
-            text = parsed.get("message", stripped)
-        except json.JSONDecodeError:
-            text = stripped
-        command = self._parse_comma_prefixed_command(text)
+        command = self._parse_comma_prefixed_command(stripped)
         if command is None:
             return UserRouteResult(enter_model=True, model_prompt=stripped, immediate_output="", exit_requested=False)
 


### PR DESCRIPTION
### Bug Description
Run command:
```shell
bub run "{\"message\": null}" 
# or
bub run '"这是一个合法的JSON"'
```
These inputs (among others) trigger an `AttributeError`:

- `{"message": null}` → `parsed` is a `dict`, but `parsed.get("message")` returns `None` → subsequent `None.startswith(...)` call crashes.
- `"这是一个合法的JSON"` → `parsed` is a `str` without a `.get()` method → `AttributeError` is raised immediately.

### Investigation
While investigating the `AttributeError` bugs, I traced the JSON parsing code back to commit `1fe1c18` (2026-02-10), where it was added to handle the old MessageBus communication format (`InboundMessage.render()`). However, after commit `9808f0f` (2026-02-14) removed the MessageBus, this parsing became obsolete—the current architecture passes plain text directly from `Channel.get_session_prompt()` through `runtime.handle_input()` to `router.route_user()`. All modern channels (telegram/discord/base) no longer use the JSON wrapper format, making this code safe to remove.

**Current Data Flow**: `Channel.get_session_prompt() -> runtime.handle_input() -> router.route_user(raw_text)`

### Resolution
Delete this dead code to reduce complexity and clarify the router's scope.

### Verification
- [x] ruff check: passed
- [x] ruff format: passed  
- [x] mypy: passed
- [x] pre-commit: passed