### PR TITLE
Make quick start procedure to work by fixing the minimal .env in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Minimal `.env`:
 
 ```bash
 BUB_MODEL=openrouter:qwen/qwen3-coder-next
-OPENROUTER_API_KEY=your_key_here
+LLM_API_KEY=your_key_here
 ```
 
 Start interactive CLI:


### PR DESCRIPTION
**Problem**

The getting started guide in `README.md` showed:

- `OPENROUTER_API_KEY=your_key_here`

But Bub resolves API keys with this priority:

- `BUB_API_KEY` > `LLM_API_KEY` > `OPENROUTER_API_KEY`

The current `env.example` already includes `LLM_API_KEY` as a placeholder by default. As a result, the default quick start flow (`cp env.example .env` + filling only `OPENROUTER_API_KEY`) can fail, because Bub can pick that value instead of `OPENROUTER_API_KEY`, causing authentication failures and a confusing first-run experience.

**Fix**

Updated the minimal `.env` example in `README.md` to use:

- `LLM_API_KEY=your_key_here`

instead of `OPENROUTER_API_KEY=your_key_here`.

This aligns the quick-start example with Bub’s actual key resolution order and avoids accidental key shadowing during onboarding.