### PR TITLE
fix: chat failed when socks proxy is enabled

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "requests>=2.32.5",
     "python-dotenv>=1.2.1",
     "any-llm-sdk[anthropic,vertexai]>=1.8.0",
+    "httpx[socks]>=0.28.1",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -266,6 +266,7 @@ dependencies = [
     { name = "any-llm-sdk", extra = ["anthropic", "vertexai"] },
     { name = "apscheduler" },
     { name = "discord-py" },
+    { name = "httpx", extra = ["socks"] },
     { name = "loguru" },
     { name = "prompt-toolkit" },
     { name = "pydantic" },
@@ -302,6 +303,7 @@ requires-dist = [
     { name = "any-llm-sdk", extras = ["anthropic", "vertexai"], specifier = ">=1.8.0" },
     { name = "apscheduler", specifier = ">=3.11.2" },
     { name = "discord-py", specifier = ">=2.6.4" },
+    { name = "httpx", extras = ["socks"], specifier = ">=0.28.1" },
     { name = "loguru", specifier = ">=0.7.2" },
     { name = "prompt-toolkit", specifier = ">=3.0.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
@@ -784,6 +786,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[package.optional-dependencies]
+socks = [
+    { name = "socksio" },
 ]
 
 [[package]]
@@ -1965,6 +1972,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "socksio"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/5c/48a7d9495be3d1c651198fd99dbb6ce190e2274d0f28b9051307bdec6b85/socksio-1.0.0.tar.gz", hash = "sha256:f88beb3da5b5c38b9890469de67d0cb0f9d494b78b106ca1845f96c10b91c4ac", size = 19055, upload-time = "2020-04-17T15:50:34.664Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/c3/6eeb6034408dac0fa653d126c9204ade96b819c936e136c5e8a6897eee9c/socksio-1.0.0-py3-none-any.whl", hash = "sha256:95dc1f15f9b34e8d7b16f06d74b8ccf48f609af32ab33c608d08761c5dcbb1f3", size = 12763, upload-time = "2020-04-17T15:50:31.878Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
When I `uv run bub` in my cluster where socks proxy enabled, it emit the error logs below:

```
ERROR    model.call.error
         Traceback (most recent call last):
           File "/Users/mengxinliu/workspace/bub/src/bub/core/model_runner.py", line 178, in _chat
             output = await self._tape.tape.run_tools_async(
           File "/Users/mengxinliu/workspace/bub/.venv/lib/python3.13/site-packages/republic/tape/session.py", line 270, in run_tools_async
             return await self._client.run_tools_async(
           File "/Users/mengxinliu/workspace/bub/.venv/lib/python3.13/site-packages/republic/clients/chat.py", line 1213, in run_tools_async
             return await self._execute_async(
           File "/Users/mengxinliu/workspace/bub/.venv/lib/python3.13/site-packages/republic/clients/chat.py", line 427, in _execute_async
             return await self._core.run_chat_async(
           File "/Users/mengxinliu/workspace/bub/.venv/lib/python3.13/site-packages/republic/core/execution.py", line 545, in run_chat_async
             for provider_name, model_id, client in self.iter_clients(model, provider):
           File "/Users/mengxinliu/workspace/bub/.venv/lib/python3.13/site-packages/republic/core/execution.py", line 142, in iter_clients
             yield provider_name, model_id, self.get_client(provider_name)
           File "/Users/mengxinliu/workspace/bub/.venv/lib/python3.13/site-packages/republic/core/execution.py", line 177, in get_client
             self._client_cache[cache_key] = AnyLLM.create(
           File "/Users/mengxinliu/workspace/bub/.venv/lib/python3.13/site-packages/any_llm/any_llm.py", line 151, in create
             return cls._create_provider(provider, api_key=api_key, api_base=api_base, **kwargs)
           File "/Users/mengxinliu/workspace/bub/.venv/lib/python3.13/site-packages/any_llm/any_llm.py", line 202, in _create_provider
             return provider_class(api_key=api_key, api_base=api_base, **kwargs)
           File "/Users/mengxinliu/workspace/bub/.venv/lib/python3.13/site-packages/any_llm/any_llm.py", line 100, in __init__
             self._init_client(
           File "/Users/mengxinliu/workspace/bub/.venv/lib/python3.13/site-packages/any_llm/providers/openai/base.py", line 129, in _init_client
             self.client = AsyncOpenAI(
           File "/Users/mengxinliu/workspace/bub/.venv/lib/python3.13/site-packages/openai/_client.py", line 517, in __init__
             super().__init__(
           File "/Users/mengxinliu/workspace/bub/.venv/lib/python3.13/site-packages/openai/_base_client.py", line 1484, in __init__
             self._client = http_client or AsyncHttpxClientWrapper(
           File "/Users/mengxinliu/workspace/bub/.venv/lib/python3.13/site-packages/openai/_base_client.py", line 1391, in __init__
             super().__init__(**kwargs)
           File "/Users/mengxinliu/workspace/bub/.venv/lib/python3.13/site-packages/httpx/_client.py", line 1415, in __init__
             else self._init_proxy_transport(
           File "/Users/mengxinliu/workspace/bub/.venv/lib/python3.13/site-packages/httpx/_client.py", line 1464, in _init_proxy_transport
             return AsyncHTTPTransport(
           File "/Users/mengxinliu/workspace/bub/.venv/lib/python3.13/site-packages/httpx/_transports/default.py", line 335, in __init__
             raise ImportError(
         ImportError: Using SOCKS proxy, but the 'socksio' package is not installed. Make sure to install httpx using `pip install httpx[socks]`.
```

And it was resolved by `uv add httpx[socks]`.
