### PR TITLE
fix: pass framework workspace to CliChannel for correct display

### DIFF
--- a/src/bub/builtin/cli.py
+++ b/src/bub/builtin/cli.py
@@ -83,7 +83,7 @@ def chat(
     if channel is None:
         typer.echo("CLI channel not found. Please check your hook implementations.")
         raise typer.Exit(1)
-    channel.set_metadata(chat_id=chat_id, session_id=session_id)  # type: ignore[attr-defined]
+    channel.set_metadata(chat_id=chat_id, session_id=session_id, workspace=ctx.obj.workspace)  # type: ignore[attr-defined]
     asyncio.run(manager.listen_and_run())
 
 

--- a/src/bub/channels/cli/__init__.py
+++ b/src/bub/channels/cli/__init__.py
@@ -49,11 +49,13 @@ class CliChannel(Channel):
         info = await self._agent.tapes.info(tape.name)
         self._last_tape_info = info
 
-    def set_metadata(self, session_id: str | None = None, chat_id: str | None = None) -> None:
+    def set_metadata(self, session_id: str | None = None, chat_id: str | None = None, workspace: Path | None = None) -> None:
         if session_id is not None:
             self._message_template["session_id"] = session_id
         if chat_id is not None:
             self._message_template["chat_id"] = chat_id
+        if workspace is not None:
+            self._workspace = workspace
 
     async def start(self, stop_event: asyncio.Event) -> None:
         self._stop_event = stop_event


### PR DESCRIPTION
- Add workspace parameter to CliChannel.set_metadata() to allow updating the workspace after initialization
- Pass framework's workspace from chat command to CliChannel via set_metadata()
- Fixes issue where welcome screen displayed current working directory instead of the --workspace argument value