### PR TITLE
Introduce effect log for semantic side-effect tracking

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,9 @@ dependencies = [
     "aiohttp>=3.13.3",
 ]
 
+[project.optional-dependencies]
+effect-log = ["ai-effectlog>=0.1.0"]
+
 [project.urls]
 Homepage = "https://bub.build"
 Repository = "https://github.com/bubbuild/bub"

--- a/src/bub/__init__.py
+++ b/src/bub/__init__.py
@@ -2,7 +2,7 @@
 
 from bub.framework import BubFramework
 from bub.hookspecs import hookimpl
-from bub.tools import tool
+from bub.tools import enable_effect_log, tool
 
-__all__ = ["BubFramework", "hookimpl", "tool"]
+__all__ = ["BubFramework", "enable_effect_log", "hookimpl", "tool"]
 __version__ = "0.3.0"

--- a/src/bub/builtin/agent.py
+++ b/src/bub/builtin/agent.py
@@ -24,7 +24,7 @@ from bub.builtin.store import ForkTapeStore
 from bub.builtin.tape import TapeService
 from bub.framework import BubFramework
 from bub.skills import discover_skills, render_skills_prompt
-from bub.tools import REGISTRY, model_tools, render_tools_prompt
+from bub.tools import EFFECT_KINDS, REGISTRY, enable_effect_log, make_adapted_handler, model_tools, render_tools_prompt, unwrap_handler
 from bub.types import State
 from bub.utils import workspace_from_state
 
@@ -39,6 +39,7 @@ class Agent:
     def __init__(self, framework: BubFramework) -> None:
         self.settings = _load_runtime_settings()
         self.framework = framework
+        self._effect_log_sessions: set[str] = set()
 
     @cached_property
     def tapes(self) -> TapeService:
@@ -61,6 +62,7 @@ class Agent:
     ) -> str:
         if not prompt:
             return "error: empty prompt"
+        self._maybe_enable_effect_log(session_id)
         tape = self.tapes.session_tape(session_id, workspace_from_state(state))
         tape.context.state.update(state)
         merge_back = not session_id.startswith("temp/")
@@ -71,6 +73,57 @@ class Agent:
             return await self._agent_loop(
                 tape=tape, prompt=prompt, model=model, allowed_skills=allowed_skills, allowed_tools=allowed_tools
             )
+
+    def _maybe_enable_effect_log(self, session_id: str) -> None:
+        """Auto-initialize effect-log for this session if BUB_EFFECT_LOG=true."""
+        if not self.settings.effect_log:
+            return
+        if not EFFECT_KINDS:
+            return
+        if session_id in self._effect_log_sessions:
+            return
+        try:
+            from effect_log import EffectKind, EffectLog, ToolDef
+        except ImportError:
+            logger.warning("effect_log: BUB_EFFECT_LOG=true but ai-effectlog is not installed. pip install bub[effect-log]")
+            return
+
+        if self.settings.effect_log_storage:
+            # User-provided storage (e.g. "memory://" or a custom sqlite path)
+            storage = self.settings.effect_log_storage
+            recover = False
+        else:
+            # Default: per-session SQLite under ~/.bub/effects/
+            effects_dir = self.settings.home / "effects"
+            effects_dir.mkdir(parents=True, exist_ok=True)
+            safe_name = session_id.replace("/", "_").replace("\\", "_")
+            db_path = effects_dir / f"{safe_name}.db"
+            storage = f"sqlite:///{db_path}"
+            recover = db_path.exists()
+
+        tooldefs = []
+        for name, kind_str in EFFECT_KINDS.items():
+            if name not in REGISTRY:
+                continue
+            tool_instance = REGISTRY[name]
+            handler = tool_instance.handler
+            if handler is None:
+                continue
+            raw = unwrap_handler(handler)
+
+            kind = getattr(EffectKind, kind_str, None)
+            if kind is None:
+                logger.warning("effect_log: unknown effect kind '{}' for tool '{}'", kind_str, name)
+                continue
+            tooldefs.append(ToolDef(name, kind, make_adapted_handler(raw, tool_instance.context)))
+
+        log = EffectLog(execution_id=session_id, tools=tooldefs, storage=storage, recover=recover)
+        enable_effect_log(log)
+        # Cap tracked sessions to prevent unbounded growth in long-running processes
+        if len(self._effect_log_sessions) >= 1000:
+            self._effect_log_sessions.clear()
+        self._effect_log_sessions.add(session_id)
+        logger.info("effect_log: enabled for session={} storage={} recover={}", session_id, storage, recover)
 
     async def _run_command(self, tape: Tape, *, line: str) -> str:
         line = line[1:].strip()

--- a/src/bub/builtin/settings.py
+++ b/src/bub/builtin/settings.py
@@ -28,6 +28,8 @@ class AgentSettings(BaseSettings):
     max_steps: int = 50
     max_tokens: int = DEFAULT_MAX_TOKENS
     model_timeout_seconds: int | None = None
+    effect_log: bool = False
+    effect_log_storage: str | None = None
 
     @classmethod
     def from_env(cls) -> AgentSettings:

--- a/src/bub/builtin/tools.py
+++ b/src/bub/builtin/tools.py
@@ -59,7 +59,7 @@ class SubAgentInput(BaseModel):
     )
 
 
-@tool(context=True)
+@tool(context=True, effect="IrreversibleWrite")
 async def bash(
     cmd: str,
     cwd: str | None = None,
@@ -83,7 +83,7 @@ async def bash(
     return shell.output.strip() or "(no output)"
 
 
-@tool(name="bash.output")
+@tool(name="bash.output", effect="ReadOnly")
 async def bash_output(shell_id: str, offset: int = 0, limit: int | None = None) -> str:
     """Read buffered output from a background shell, with optional offset/limit for incremental polling."""
     shell = shell_manager.get(shell_id)
@@ -98,7 +98,7 @@ async def bash_output(shell_id: str, offset: int = 0, limit: int | None = None) 
     return f"id: {shell.shell_id}\nstatus: {shell.status}\nexit_code: {exit_code}\nnext_offset: {end}\noutput:\n{body}"
 
 
-@tool(name="bash.kill")
+@tool(name="bash.kill", effect="IrreversibleWrite")
 async def kill_bash(shell_id: str) -> str:
     """Terminate a background shell process."""
     shell = shell_manager.get(shell_id)
@@ -109,7 +109,7 @@ async def kill_bash(shell_id: str) -> str:
     return f"id: {shell.shell_id}\nstatus: {shell.status}\nexit_code: {shell.returncode}"
 
 
-@tool(context=True, name="fs.read")
+@tool(context=True, name="fs.read", effect="ReadOnly")
 def fs_read(path: str, offset: int = 0, limit: int | None = None, *, context: ToolContext) -> str:
     """Read a text file and return its content. Supports optional pagination with offset and limit."""
     resolved_path = _resolve_path(context, path)
@@ -120,7 +120,7 @@ def fs_read(path: str, offset: int = 0, limit: int | None = None, *, context: To
     return "\n".join(lines[start:end])
 
 
-@tool(context=True, name="fs.write")
+@tool(context=True, name="fs.write", effect="IdempotentWrite")
 def fs_write(path: str, content: str, *, context: ToolContext) -> str:
     """Write content to a text file."""
     resolved_path = _resolve_path(context, path)
@@ -129,7 +129,7 @@ def fs_write(path: str, content: str, *, context: ToolContext) -> str:
     return f"wrote: {resolved_path}"
 
 
-@tool(context=True, name="fs.edit")
+@tool(context=True, name="fs.edit", effect="IdempotentWrite")
 def fs_edit(path: str, old: str, new: str, start: int = 0, *, context: ToolContext) -> str:
     """Edit a text file by replacing old text with new text. You can specify the line number to start searching for the old text."""
     resolved_path = _resolve_path(context, path)
@@ -145,7 +145,7 @@ def fs_edit(path: str, old: str, new: str, start: int = 0, *, context: ToolConte
     return f"edited: {resolved_path}"
 
 
-@tool(context=True, name="skill")
+@tool(context=True, name="skill", effect="ReadOnly")
 def skill_describe(name: str, *, context: ToolContext) -> str:
     """Load the skill content by name. Return the location and skill content."""
     from bub.utils import workspace_from_state
@@ -162,7 +162,7 @@ def skill_describe(name: str, *, context: ToolContext) -> str:
     return f"Location: {skill.location}\n---\n{skill.body() or '(no content)'}"
 
 
-@tool(context=True, name="tape.info")
+@tool(context=True, name="tape.info", effect="ReadOnly")
 async def tape_info(context: ToolContext) -> str:
     """Get information about the current tape, such as number of entries and anchors."""
     agent = _get_agent(context)
@@ -177,7 +177,7 @@ async def tape_info(context: ToolContext) -> str:
     )
 
 
-@tool(context=True, name="tape.search", model=SearchInput)
+@tool(context=True, name="tape.search", model=SearchInput, effect="ReadOnly")
 async def tape_search(param: SearchInput, *, context: ToolContext) -> str:
     """Search for entries in the current tape that match the query. Returns a list of matching entries."""
     agent = _get_agent(context)
@@ -200,7 +200,7 @@ async def tape_search(param: SearchInput, *, context: ToolContext) -> str:
     return f"[tape.search]: {len(entries)} matches" + "".join(f"\n{line}" for line in lines)
 
 
-@tool(context=True, name="tape.reset")
+@tool(context=True, name="tape.reset", effect="IrreversibleWrite")
 async def tape_reset(archive: bool = False, *, context: ToolContext) -> str:
     """Reset the current tape, optionally archiving it."""
     agent = _get_agent(context)
@@ -208,7 +208,7 @@ async def tape_reset(archive: bool = False, *, context: ToolContext) -> str:
     return result
 
 
-@tool(context=True, name="tape.handoff")
+@tool(context=True, name="tape.handoff", effect="IdempotentWrite")
 async def tape_handoff(name: str = "handoff", summary: str = "", *, context: ToolContext) -> str:
     """Add a handoff anchor to the current tape."""
     agent = _get_agent(context)
@@ -216,7 +216,7 @@ async def tape_handoff(name: str = "handoff", summary: str = "", *, context: Too
     return f"anchor added: {name}"
 
 
-@tool(context=True, name="tape.anchors")
+@tool(context=True, name="tape.anchors", effect="ReadOnly")
 async def tape_anchors(*, context: ToolContext) -> str:
     """List anchors in the current tape."""
     agent = _get_agent(context)
@@ -226,7 +226,7 @@ async def tape_anchors(*, context: ToolContext) -> str:
     return "\n".join(f"- {anchor.name}" for anchor in anchors)
 
 
-@tool(name="web.fetch")
+@tool(name="web.fetch", effect="ReadOnly")
 async def web_fetch(url: str, headers: dict | None = None, timeout: int | None = None) -> str:
     """Fetch(GET) the content of a web page, returning markdown if possible."""
     import aiohttp
@@ -242,7 +242,7 @@ async def web_fetch(url: str, headers: dict | None = None, timeout: int | None =
         return await response.text()
 
 
-@tool(name="subagent", context=True, model=SubAgentInput)
+@tool(name="subagent", context=True, model=SubAgentInput, effect="IrreversibleWrite")
 async def run_subagent(param: SubAgentInput, *, context: ToolContext) -> str:
     """Run a task with sub-agent using specific model and session."""
     agent = _get_agent(context)
@@ -268,7 +268,7 @@ async def run_subagent(param: SubAgentInput, *, context: ToolContext) -> str:
     )
 
 
-@tool(name="help")
+@tool(name="help", effect="ReadOnly")
 def show_help() -> str:
     """Show a help message."""
     return (

--- a/src/bub/tools.py
+++ b/src/bub/tools.py
@@ -3,15 +3,22 @@ import json
 import time
 from collections.abc import Callable, Iterable
 from dataclasses import replace
-from typing import Any, overload
+from typing import Any, Literal, overload
 
 from loguru import logger
 from pydantic import BaseModel
 from republic import Tool
 from republic import tool as republic_tool
 
+# Valid effect kind strings for the @tool(effect=...) parameter.
+EffectKindStr = Literal["ReadOnly", "IdempotentWrite", "Compensatable", "IrreversibleWrite", "ReadThenWrite"]
+
 # Central registry for tools. Tools defined with the @tool decorator are automatically added here.
 REGISTRY: dict[str, Tool] = {}
+
+# Effect kind registry. Maps tool name → effect kind string (e.g. "ReadOnly", "IrreversibleWrite").
+# Populated when @tool(effect="...") is used. Consumed by enable_effect_log().
+EFFECT_KINDS: dict[str, str] = {}
 
 
 def _add_logging(tool: Tool) -> Tool:
@@ -38,6 +45,7 @@ def _add_logging(tool: Tool) -> Tool:
             logger.info("tool.call.success name={} elapsed_time={:.2f}ms", tool.name, elapsed_time)
             return result
 
+    wrapped.__wrapped__ = tool.handler
     return replace(tool, handler=wrapped)
 
 
@@ -88,6 +96,7 @@ def tool(
     model: type[BaseModel] | None = ...,
     description: str | None = ...,
     context: bool = ...,
+    effect: EffectKindStr | None = ...,
 ) -> Tool: ...
 
 
@@ -99,6 +108,7 @@ def tool(
     model: type[BaseModel] | None = ...,
     description: str | None = ...,
     context: bool = ...,
+    effect: EffectKindStr | None = ...,
 ) -> Callable[[Callable], Tool]: ...
 
 
@@ -109,8 +119,21 @@ def tool(
     model: type[BaseModel] | None = None,
     description: str | None = None,
     context: bool = False,
+    effect: EffectKindStr | None = None,
 ) -> Tool | Callable[[Callable], Tool]:
-    """Decorator to convert a function into a Tool instance."""
+    """Decorator to convert a function into a Tool instance.
+
+    Args:
+        func: The function to wrap.
+        name: Override the tool name (default: derived from function name).
+        model: Pydantic model for structured input.
+        description: Override the tool description.
+        context: Whether the tool receives a ToolContext.
+        effect: Semantic effect kind for crash recovery via effect-log.
+            One of: "ReadOnly", "IdempotentWrite", "Compensatable",
+            "IrreversibleWrite", "ReadThenWrite". When set, the tool is
+            eligible for WAL-based crash recovery if effect-log is enabled.
+    """
 
     result = republic_tool(
         func=func,
@@ -121,14 +144,32 @@ def tool(
     )
     if isinstance(result, Tool):
         REGISTRY[result.name] = result
+        if effect is not None:
+            EFFECT_KINDS[result.name] = effect
         return _add_logging(result)
 
     def decorator(func: Callable) -> Tool:
         tool_instance = _add_logging(result(func))
         REGISTRY[tool_instance.name] = tool_instance
+        if effect is not None:
+            EFFECT_KINDS[tool_instance.name] = effect
         return tool_instance
 
     return decorator
+
+
+def unwrap_handler(handler: Callable) -> Callable:
+    """Strip logging and pydantic wrappers to get the raw function.
+
+    The wrapping chain is: logging_wrapper → republic (pydantic validate_call) → raw.
+    ``_add_logging`` sets ``__wrapped__`` → republic handler.
+    Republic's validate_call sets ``raw_function`` / ``__wrapped__`` → raw function.
+    """
+    # Skip logging wrapper
+    raw = getattr(handler, "__wrapped__", handler)
+    # Skip pydantic validate_call
+    raw = getattr(raw, "raw_function", getattr(raw, "__wrapped__", raw))
+    return raw
 
 
 def _to_model_name(name: str) -> str:
@@ -151,3 +192,117 @@ def render_tools_prompt(tools: Iterable[Tool]) -> str:
             line += f": {tool.description}"
         lines.append(line)
     return f"<available_tools>\n{'\n'.join(lines)}\n</available_tools>"
+
+
+class _EffectLogContext:
+    """Shared storage for passing ToolContext through effect-log's execute cycle.
+
+    Uses a plain attribute instead of threading.local because the Rust
+    effect-log extension invokes the Python callback from a different OS
+    thread (while holding the GIL).  A threading.local would see a fresh
+    namespace on that callback thread, losing the stored context.
+
+    Safety: the GIL prevents concurrent Python execution and log.execute()
+    is synchronous, so no interleaving can occur between set and read.
+    """
+
+    value: Any = None
+
+
+_effect_log_context = _EffectLogContext()
+
+
+def make_adapted_handler(raw: Callable, needs_context: bool) -> Callable:
+    """Build an adapted handler for effect-log ``ToolDef``.
+
+    Wraps the raw (unwrapped) handler to:
+    - inject ``ToolContext`` from ``_effect_log_context`` when the tool requires it,
+    - handle async execution in a sync context (as required by effect-log callbacks).
+    """
+
+    def adapted(args: dict) -> Any:
+        kwargs = dict(args)
+        if needs_context:
+            ctx = getattr(_effect_log_context, "value", None)
+            if ctx is not None:
+                kwargs["context"] = ctx
+
+        result = raw(**kwargs)
+        if inspect.isawaitable(result):
+            import asyncio
+
+            loop = asyncio.new_event_loop()
+            try:
+                return loop.run_until_complete(result)
+            finally:
+                loop.close()
+        return result
+
+    return adapted
+
+
+def _add_effect_log(tool_instance: Tool, log: Any) -> Tool:
+    """Wrap a tool's handler to route calls through an effect-log WAL.
+
+    Follows the same pattern as ``_add_logging``: returns a new Tool via
+    ``dataclasses.replace()`` with a wrapped handler.
+    """
+    if tool_instance.handler is None:
+        return tool_instance
+
+    # Unwrap any previous effect-log layer to prevent stacking
+    original_handler = getattr(tool_instance.handler, "__effect_log_wrapped__", tool_instance.handler)
+
+    async def wrapped(*args, **kwargs):
+        call_args = {k: v for k, v in kwargs.items() if k != "context"}
+        for i, v in enumerate(args):
+            call_args[f"_pos_{i}"] = v
+
+        # Stash context so the adapted handler can retrieve it for replay
+        _effect_log_context.value = kwargs.get("context")
+        try:
+            result = log.execute(tool_instance.name, call_args)
+        finally:
+            _effect_log_context.value = None
+
+        if isinstance(result, str):
+            return result
+        try:
+            return json.dumps(result)
+        except (TypeError, ValueError):
+            return str(result)
+
+    wrapped.__effect_log_wrapped__ = original_handler
+    return replace(tool_instance, handler=wrapped)
+
+
+def enable_effect_log(log: Any, registry: dict[str, Tool] | None = None) -> None:
+    """Enable effect-log crash recovery for all tools that declared an ``effect``.
+
+    Wraps the handler of each tool whose name appears in ``EFFECT_KINDS``
+    so that calls go through the effect-log WAL instead of executing directly.
+
+    Safe to call multiple times (e.g. for different sessions): any existing
+    effect-log wrapper is unwrapped before the new one is applied.
+
+    Call this once at startup, after tools are registered and before the
+    agent begins processing::
+
+        from effect_log import EffectLog
+        from bub.tools import enable_effect_log
+
+        log = EffectLog(execution_id="...", tools=tooldefs, storage="sqlite:///effects.db")
+        enable_effect_log(log)
+
+    Args:
+        log: An initialized ``EffectLog`` instance.
+        registry: Tool registry to wrap. Defaults to the global ``REGISTRY``.
+    """
+    target = registry if registry is not None else REGISTRY
+    for name, tool_instance in list(target.items()):
+        if name in EFFECT_KINDS:
+            # Restore pre-effect-log handler if previously wrapped
+            prev = getattr(tool_instance.handler, "__effect_log_wrapped__", None)
+            if prev is not None:
+                tool_instance = replace(tool_instance, handler=prev)
+            target[name] = _add_effect_log(tool_instance, log)

--- a/tests/test_effect_log.py
+++ b/tests/test_effect_log.py
@@ -1,0 +1,171 @@
+"""End-to-end tests for effect-log integration with bub's builtin tools.
+
+Demonstrates that when effect-log is enabled:
+1. bash (IrreversibleWrite) is NOT re-executed on recovery
+2. fs.read (ReadOnly) IS replayed for fresh data
+3. fs.write (IdempotentWrite) returns sealed result on recovery
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from republic import ToolContext
+
+from bub.builtin.tools import bash, fs_read, fs_write
+from bub.tools import EFFECT_KINDS, REGISTRY, enable_effect_log, make_adapted_handler, unwrap_handler
+
+
+def _tool_context(workspace: Path) -> ToolContext:
+    return ToolContext(tape="test-tape", run_id="test-run", state={"_runtime_workspace": str(workspace)})
+
+
+def _make_tooldefs(tool_names: list[str]):
+    """Build EffectLog ToolDef entries for the given builtin tools."""
+    from effect_log import EffectKind, ToolDef
+
+    defs = []
+    for name in tool_names:
+        if name not in EFFECT_KINDS or name not in REGISTRY:
+            continue
+        tool_instance = REGISTRY[name]
+        handler = tool_instance.handler
+        if handler is None:
+            continue
+        raw = unwrap_handler(handler)
+        kind = getattr(EffectKind, EFFECT_KINDS[name])
+        defs.append(ToolDef(name, kind, make_adapted_handler(raw, tool_instance.context)))
+    return defs
+
+
+@pytest.fixture
+def workspace(tmp_path):
+    """Create a workspace with a test file."""
+    config = tmp_path / "config.toml"
+    config.write_text('[deploy]\nregion = "us-east-1"\n')
+    return tmp_path
+
+
+@pytest.fixture
+def effect_db(tmp_path):
+    """Return a fresh sqlite storage URI."""
+    return f"sqlite:///{tmp_path / 'effects.db'}"
+
+
+@pytest.mark.asyncio
+async def test_e2e_builtin_tools_crash_recovery(workspace, effect_db):
+    """Full cycle with real builtin tools: execute → crash → recover.
+
+    Scenario: an agent reads a config, runs a deploy command, then writes
+    a status file. After a crash, the deploy command must NOT re-execute.
+    """
+    from effect_log import EffectLog
+
+    tool_names = ["fs.read", "bash", "fs.write"]
+    ctx = _tool_context(workspace)
+
+    # Track real calls via wrapper
+    call_counts = {"fs.read": 0, "bash": 0, "fs.write": 0}
+    original_handlers = {name: REGISTRY[name].handler for name in tool_names}
+
+    # -- Phase 1: Normal execution -------------------------------------------
+
+    tooldefs = _make_tooldefs(tool_names)
+    log = EffectLog(execution_id="deploy-001", tools=tooldefs, storage=effect_db)
+    enable_effect_log(log)
+
+    # 1. Read config (ReadOnly)
+    r1 = await REGISTRY["fs.read"].run(path=str(workspace / "config.toml"), context=ctx)
+    assert "us-east-1" in r1
+
+    # 2. Deploy via bash (IrreversibleWrite)
+    r2 = await REGISTRY["bash"].run(cmd="echo deployed-to-prod", context=ctx)
+    assert "deployed-to-prod" in r2
+
+    # 3. Write status (IdempotentWrite)
+    r3 = await REGISTRY["fs.write"].run(
+        path=str(workspace / "status.txt"), content="deployed", context=ctx
+    )
+    assert "wrote:" in r3
+
+    # Verify history
+    history = log.history()
+    assert len(history) == 3
+    assert history[0]["effect_kind"] == "ReadOnly"
+    assert history[1]["effect_kind"] == "IrreversibleWrite"
+    assert history[2]["effect_kind"] == "IdempotentWrite"
+
+    # -- Phase 2: Crash recovery ---------------------------------------------
+
+    # Restore original handlers to re-wrap (simulates new process)
+    from dataclasses import replace as dc_replace
+
+    for name, handler in original_handlers.items():
+        REGISTRY[name] = dc_replace(REGISTRY[name], handler=handler)
+
+    # Get raw (unwrapped) handlers for counting wrappers to call
+    original_raw = {name: unwrap_handler(REGISTRY[name].handler) for name in tool_names}
+
+    # Install counting handlers BEFORE building tooldefs so adapted captures them
+    async def counting_bash(*args, **kwargs):
+        call_counts["bash"] += 1
+        return await original_raw["bash"](*args, **kwargs)
+
+    def counting_fs_read(*args, **kwargs):
+        call_counts["fs.read"] += 1
+        return original_raw["fs.read"](*args, **kwargs)
+
+    def counting_fs_write(*args, **kwargs):
+        call_counts["fs.write"] += 1
+        return original_raw["fs.write"](*args, **kwargs)
+
+    REGISTRY["bash"] = dc_replace(REGISTRY["bash"], handler=counting_bash)
+    REGISTRY["fs.read"] = dc_replace(REGISTRY["fs.read"], handler=counting_fs_read)
+    REGISTRY["fs.write"] = dc_replace(REGISTRY["fs.write"], handler=counting_fs_write)
+
+    tooldefs2 = _make_tooldefs(tool_names)
+    log2 = EffectLog(execution_id="deploy-001", tools=tooldefs2, storage=effect_db, recover=True)
+    enable_effect_log(log2)
+
+    # Re-execute the same sequence
+    r1 = await REGISTRY["fs.read"].run(path=str(workspace / "config.toml"), context=ctx)
+    r2 = await REGISTRY["bash"].run(cmd="echo deployed-to-prod", context=ctx)
+    r3 = await REGISTRY["fs.write"].run(
+        path=str(workspace / "status.txt"), content="deployed", context=ctx
+    )
+
+    # Results are identical (sealed or replayed)
+    assert "us-east-1" in r1
+    assert "deployed-to-prod" in r2
+    assert "wrote:" in r3
+
+    # THE KEY: bash was NOT re-executed
+    assert call_counts["fs.read"] == 1, "ReadOnly: replayed for fresh data"
+    assert call_counts["bash"] == 0, "IrreversibleWrite: sealed, NOT re-executed"
+    assert call_counts["fs.write"] == 0, "IdempotentWrite: sealed, NOT re-executed"
+
+
+@pytest.mark.asyncio
+async def test_builtin_tools_have_effect_kinds():
+    """All builtin tools should declare their effect kind."""
+    expected = {
+        "bash": "IrreversibleWrite",
+        "bash.output": "ReadOnly",
+        "bash.kill": "IrreversibleWrite",
+        "fs.read": "ReadOnly",
+        "fs.write": "IdempotentWrite",
+        "fs.edit": "IdempotentWrite",
+        "skill": "ReadOnly",
+        "tape.info": "ReadOnly",
+        "tape.search": "ReadOnly",
+        "tape.reset": "IrreversibleWrite",
+        "tape.handoff": "IdempotentWrite",
+        "tape.anchors": "ReadOnly",
+        "web.fetch": "ReadOnly",
+        "subagent": "IrreversibleWrite",
+        "help": "ReadOnly",
+    }
+    for name, kind in expected.items():
+        assert name in EFFECT_KINDS, f"{name} should have an effect kind"
+        assert EFFECT_KINDS[name] == kind, f"{name}: expected {kind}, got {EFFECT_KINDS[name]}"

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -6,7 +6,7 @@ import pytest
 from loguru import logger
 from pydantic import BaseModel
 
-from bub.tools import REGISTRY, model_tools, render_tools_prompt, tool
+from bub.tools import EFFECT_KINDS, REGISTRY, enable_effect_log, model_tools, render_tools_prompt, tool
 
 
 class EchoInput(BaseModel):
@@ -109,3 +109,97 @@ def test_render_tools_prompt_renders_available_tools_block() -> None:
 
 def test_render_tools_prompt_returns_empty_string_for_empty_input() -> None:
     assert render_tools_prompt([]) == ""
+
+
+def test_effect_parameter_populates_effect_kinds_registry() -> None:
+    tool_name = "tests.effect_tool"
+    REGISTRY.pop(tool_name, None)
+    EFFECT_KINDS.pop(tool_name, None)
+
+    @tool(name=tool_name, effect="IrreversibleWrite")
+    def effect_tool() -> str:
+        return "done"
+
+    assert EFFECT_KINDS[tool_name] == "IrreversibleWrite"
+    assert REGISTRY[tool_name] is effect_tool
+
+
+def test_effect_parameter_none_does_not_register_effect_kind() -> None:
+    tool_name = "tests.no_effect_tool"
+    REGISTRY.pop(tool_name, None)
+    EFFECT_KINDS.pop(tool_name, None)
+
+    @tool(name=tool_name)
+    def no_effect_tool() -> str:
+        return "done"
+
+    assert tool_name not in EFFECT_KINDS
+    assert REGISTRY[tool_name] is no_effect_tool
+
+
+def test_effect_parameter_works_with_decorator_factory() -> None:
+    tool_name = "tests.factory_effect"
+    REGISTRY.pop(tool_name, None)
+    EFFECT_KINDS.pop(tool_name, None)
+
+    @tool(name=tool_name, description="test", effect="ReadOnly")
+    def factory_effect(value: str) -> str:
+        return value
+
+    assert EFFECT_KINDS[tool_name] == "ReadOnly"
+
+
+@pytest.mark.asyncio
+async def test_enable_effect_log_wraps_handlers() -> None:
+    tool_name = "tests.wrappable"
+    REGISTRY.pop(tool_name, None)
+    EFFECT_KINDS.pop(tool_name, None)
+    call_count = 0
+
+    @tool(name=tool_name, effect="IdempotentWrite")
+    def wrappable(msg: str) -> str:
+        nonlocal call_count
+        call_count += 1
+        return f"original: {msg}"
+
+    # Create a mock EffectLog that records calls
+    executed: list[tuple[str, dict]] = []
+
+    class MockEffectLog:
+        def execute(self, name: str, args: dict):
+            executed.append((name, args))
+            return f"sealed: {args.get('msg', '')}"
+
+    mock_log = MockEffectLog()
+    test_registry = {tool_name: REGISTRY[tool_name]}
+    enable_effect_log(mock_log, registry=test_registry)
+
+    # Call the wrapped tool
+    result = await test_registry[tool_name].run(msg="hello")
+
+    assert result == "sealed: hello"
+    assert len(executed) == 1
+    assert executed[0] == (tool_name, {"msg": "hello"})
+    assert call_count == 0  # original handler was NOT called
+
+
+@pytest.mark.asyncio
+async def test_enable_effect_log_skips_tools_without_effect() -> None:
+    tool_name = "tests.not_wrapped"
+    REGISTRY.pop(tool_name, None)
+    EFFECT_KINDS.pop(tool_name, None)
+
+    @tool(name=tool_name)
+    def not_wrapped(msg: str) -> str:
+        return f"original: {msg}"
+
+    class MockEffectLog:
+        def execute(self, name: str, args: dict):
+            raise AssertionError("should not be called")
+
+    test_registry = {tool_name: REGISTRY[tool_name]}
+    enable_effect_log(MockEffectLog(), registry=test_registry)
+
+    # Tool without effect should still run its original handler
+    result = await test_registry[tool_name].run(msg="hello")
+    assert result == "original: hello"

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,19 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "ai-effectlog"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/53/ac072b5d0d99625d8dce9dee7111a70f22668d5deb987ee6acbd0538ea67/ai_effectlog-0.1.0.tar.gz", hash = "sha256:3fe20c1c633b070ef3e573b95a1260be68fb398e6473a9201ac21f48727172b7", size = 41415, upload-time = "2026-03-15T05:11:27.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/b8/e1fe1390f5c2cd09ffdd12229764065f68c10e8b11b313e91867bd8f8341/ai_effectlog-0.1.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:66bc7136a71db1f989762b6e04f881882f8ec2ef9ee4136a1be0bc22c0da3a62", size = 1735596, upload-time = "2026-03-15T05:11:16.287Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/b5/56a727c1616152dd831f36d802d3aa0757d777e2c5fd94a369fe5a6c7f8e/ai_effectlog-0.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3a126a3e28371e393030eb1bec6bb8e7eef0aa699f2bd703a893553af29bb97f", size = 1655797, upload-time = "2026-03-15T05:11:17.865Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/a1/8333d628a7bb4d8cc3af8ae8de93326e1a148d082841ec939d460cbbf038/ai_effectlog-0.1.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:655b2e73f8ef6a75eb9ad810fc7aa474d65c030ca6654e2c8020049c35c6e0e3", size = 1565094, upload-time = "2026-03-15T05:11:19.203Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/25/1eadff93db93e8c424f088b2dedcaf8d08a46f3e9d7abfb4a4ca9476f52a/ai_effectlog-0.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:66a5e203c4a4ade8d58ddbbadd37c2fc0f64919238b766e67dadf372e7dd9ddb", size = 1525159, upload-time = "2026-03-15T05:11:21.079Z" },
+    { url = "https://files.pythonhosted.org/packages/81/95/378d9fedbe37229380d3a200be401255a54d8e48ed04f58d297672ab08d6/ai_effectlog-0.1.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2383ee19431e3da47113cfdf56dfc52d2856e0265e1588f98fed7a1e34415fc0", size = 1564662, upload-time = "2026-03-15T05:11:22.811Z" },
+]
+
+[[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -226,6 +239,11 @@ dependencies = [
     { name = "typer" },
 ]
 
+[package.optional-dependencies]
+effect-log = [
+    { name = "ai-effectlog" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "mkdocs" },
@@ -243,6 +261,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "ai-effectlog", marker = "extra == 'effect-log'", specifier = ">=0.1.0" },
     { name = "aiohttp", specifier = ">=3.13.3" },
     { name = "any-llm-sdk", extras = ["anthropic"] },
     { name = "loguru", specifier = ">=0.7.2" },
@@ -257,6 +276,7 @@ requires-dist = [
     { name = "rich", specifier = ">=13.0.0" },
     { name = "typer", specifier = ">=0.9.0" },
 ]
+provides-extras = ["effect-log"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
  - Introduce effect-log integration for semantic side-effect tracking and WAL-based crash recovery on agent tool calls
  - Add effect parameter to the @tool() decorator (ReadOnly, IdempotentWrite, IrreversibleWrite, etc.) that classifies each tool's side-effect semantics
  - Annotate all 15 builtin tools with their effect kinds (e.g. bash → IrreversibleWrite, fs.read → ReadOnly, fs.write → IdempotentWrite)
  - Wire up automatic effect-log enablement in the Agent via BUB_EFFECT_LOG=true, with per-session SQLite storage under ~/.bub/effects/
  - On crash recovery, the effect-log replays or skips tool calls based on their kind: ReadOnly tools are re-executed for fresh data, IrreversibleWrite tools return their sealed result without re-execution, and IdempotentWrite tools also return sealed results
  - ai-effectlog is an optional dependency (pip install bub[effect-log])