### PR TITLE
docs(telegram): add .env loading instruction

### DIFF
--- a/src/skills/telegram/SKILL.md
+++ b/src/skills/telegram/SKILL.md
@@ -14,10 +14,12 @@ metadata:
 
 Agent-facing execution guide for Telegram outbound communication.
 
+# Load environment variables from .env first
+set -a; source .env 2>/dev/null || true; set +a
+
 Assumption: `BUB_TELEGRAM_TOKEN` is already available.
 
 ## Required Inputs
-
 Collect these before execution:
 
 - `chat_id` (required)


### PR DESCRIPTION
## Changes

Add shell command to load environment variables from .env file in telegram skill documentation.

```bash
# Load environment variables from .env first
set -a; source .env 2>/dev/null || true; set +a
```

## Motivation

Ensures `BUB_TELEGRAM_TOKEN` is properly loaded from .env file before executing telegram skill scripts, improving the skill's usability and documentation completeness.

## Testing

- [x] Verified syntax is correct
- [x] Consistent with shell best practices for .env loading