### PR TITLE
fix: use dynamic bash lookup and stdin message passing for Telegram scripts

### DIFF
--- a/src/bub/builtin/shell_manager.py
+++ b/src/bub/builtin/shell_manager.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import os
+import shutil
 import uuid
 from dataclasses import dataclass, field
 
@@ -39,7 +40,7 @@ class ShellManager:
             cwd=cwd,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
-            executable="/bin/bash" if os.name != "nt" else None,
+            executable=(shutil.which("bash") or shutil.which("sh")) if os.name != "nt" else None,
         )
         shell = ManagedShell(shell_id=f"bash-{uuid.uuid4().hex[:8]}", cmd=cmd, cwd=cwd, process=process)
         shell.read_tasks.extend([

--- a/src/skills/telegram/SKILL.md
+++ b/src/skills/telegram/SKILL.md
@@ -28,7 +28,7 @@ Collect these before execution:
 1. If handling a Telegram message and `message_id` is known, send a reply message with `--reply-to`.
 2. If there is no message to reply to, send a normal message to `chat_id`.
 3. For long-running tasks, optionally send one progress message, then edit that same message for final status.
-4. For multi-line text, pass the content via heredoc command substitution instead of embedding raw line breaks in quoted strings.
+4. **ALWAYS pass message content via stdin using heredoc pipe and `--message -` (or `--text -`).** NEVER embed message text directly in shell arguments — special characters like `'`, `"`, `$`, `!` will be mangled or cause syntax errors.
 5. Avoid emitting HTML tags in message content; use Markdown for formatting instead.
 
 ## Bot to co-Bot Communication
@@ -75,23 +75,19 @@ But when any explanation or details are needed, use a normal reply instead.
 Paths are relative to this skill directory.
 
 ```bash
-# Preferred: pipe message via stdin to avoid shell escaping issues
-cat <<'EOF' | uv run ${SKILL_DIR}/scripts/telegram_send.py --chat-id <CHAT_ID> --message -
-Your message content here, with `backticks`, $variables, and "quotes" safely preserved.
+# Send message (ALWAYS use heredoc stdin, never inline text in arguments)
+cat << 'EOF' | uv run ${SKILL_DIR}/scripts/telegram_send.py --chat-id <CHAT_ID> --message -
+Your message content here.
+Special characters are safe: $100, "quotes", 'apostrophes', !exclamation
 EOF
 
-# Simple text (no special characters)
-uv run ${SKILL_DIR}/scripts/telegram_send.py \
-  --chat-id <CHAT_ID> \
-  --message 'simple text'
-
-# Reply via stdin
-cat <<'EOF' | uv run ${SKILL_DIR}/scripts/telegram_send.py --chat-id <CHAT_ID> --reply-to <MESSAGE_ID> --message -
+# Reply to a specific message
+cat << 'EOF' | uv run ${SKILL_DIR}/scripts/telegram_send.py --chat-id <CHAT_ID> --reply-to <MESSAGE_ID> --message -
 Reply content here.
 EOF
 
-# Edit via stdin
-cat <<'EOF' | uv run ${SKILL_DIR}/scripts/telegram_edit.py --chat-id <CHAT_ID> --message-id <MESSAGE_ID> --text -
+# Edit an existing message
+cat << 'EOF' | uv run ${SKILL_DIR}/scripts/telegram_edit.py --chat-id <CHAT_ID> --message-id <MESSAGE_ID> --text -
 Updated content here.
 EOF
 ```

--- a/src/skills/telegram/SKILL.md
+++ b/src/skills/telegram/SKILL.md
@@ -75,33 +75,25 @@ But when any explanation or details are needed, use a normal reply instead.
 Paths are relative to this skill directory.
 
 ```bash
-# Send simple text with SINGLE quotes
-uv run ${SKILL_DIR}/scripts/telegram_send.py \
-  --chat-id <CHAT_ID> \
-  --message '<TEXT>'
-
-# Or, send multi-line message using heredoc and double quotes
-uv run ${SKILL_DIR}/scripts/telegram_send.py \
-  --chat-id <CHAT_ID> \
-  --message "$(cat <<'EOF'
-Build finished successfully.
-Summary:
-- 12 tests passed
-- 0 failures
+# Preferred: pipe message via stdin to avoid shell escaping issues
+cat <<'EOF' | uv run ${SKILL_DIR}/scripts/telegram_send.py --chat-id <CHAT_ID> --message -
+Your message content here, with `backticks`, $variables, and "quotes" safely preserved.
 EOF
-)"
 
-# Send reply to a specific message
+# Simple text (no special characters)
 uv run ${SKILL_DIR}/scripts/telegram_send.py \
   --chat-id <CHAT_ID> \
-  --message '<TEXT>' \
-  --reply-to <MESSAGE_ID>
+  --message 'simple text'
 
-# Edit existing message
-uv run ${SKILL_DIR}/scripts/telegram_edit.py \
-  --chat-id <CHAT_ID> \
-  --message-id <MESSAGE_ID> \
-  --text '<TEXT>'
+# Reply via stdin
+cat <<'EOF' | uv run ${SKILL_DIR}/scripts/telegram_send.py --chat-id <CHAT_ID> --reply-to <MESSAGE_ID> --message -
+Reply content here.
+EOF
+
+# Edit via stdin
+cat <<'EOF' | uv run ${SKILL_DIR}/scripts/telegram_edit.py --chat-id <CHAT_ID> --message-id <MESSAGE_ID> --text -
+Updated content here.
+EOF
 ```
 
 When sending message to a bot, either use `--reply-to` argument or pass `--source-is-bot` with `--source-username` otherwise the bot will not receive the message.
@@ -113,7 +105,7 @@ For other actions that not covered by these scripts, use `curl` to call Telegram
 ### `telegram_send.py`
 
 - `--chat-id`, `-c`: required, supports comma-separated ids
-- `--message`, `-m`: required
+- `--message`, `-m`: required (use `-` to read from stdin)
 - `--reply-to`, `-r`: optional
 - `--token`, `-t`: optional (normally not needed)
 
@@ -121,5 +113,5 @@ For other actions that not covered by these scripts, use `curl` to call Telegram
 
 - `--chat-id`, `-c`: required
 - `--message-id`, `-m`: required
-- `--text`, `-t`: required
+- `--text`, `-t`: required (use `-` to read from stdin)
 - `--token`: optional (normally not needed)

--- a/src/skills/telegram/scripts/telegram_edit.py
+++ b/src/skills/telegram/scripts/telegram_edit.py
@@ -90,7 +90,8 @@ def main():
         sys.exit(1)
 
     try:
-        edit_message(bot_token, args.chat_id, args.message_id, args.text)
+        text = sys.stdin.read() if args.text == "-" else args.text
+        edit_message(bot_token, args.chat_id, args.message_id, text)
         print(f"✅ Message {args.message_id} edited successfully")
     except requests.HTTPError as e:
         print(f"❌ HTTP Error: {e}")

--- a/src/skills/telegram/scripts/telegram_send.py
+++ b/src/skills/telegram/scripts/telegram_send.py
@@ -150,7 +150,7 @@ def main():
     # Parse chat IDs
     chat_id = args.chat_id.strip()
     reply_to = args.reply_to
-    message = args.message
+    message = sys.stdin.read() if args.message == "-" else args.message
 
     if args.source_is_bot and not reply_to and not message.startswith("/"):
         if not args.source_username:


### PR DESCRIPTION
## Problem

When the agent sends Telegram messages via `bash` tool, the message content is embedded directly in shell command arguments. This causes two issues:

1. **Shell escaping failures**: Special characters (`'`, `"`, `$`, `!`, backticks) in message content are interpreted by the shell, resulting in truncated messages, variable substitution, or syntax errors like `Syntax error: word unexpected (expecting ")")`.

2. **Hardcoded `/bin/bash` path**: `shell_manager.py` assumed bash lives at `/bin/bash`, which fails on FreeBSD where bash is installed at `/usr/local/bin/bash`.

The core problem is architectural: **arbitrary text content should never pass through shell interpretation**. This is especially problematic with smaller models (e.g. Gemma 31B) that tend to add redundant `/bin/sh -c '...'` wrappers, creating nested shell layers that make correct escaping nearly impossible.

## Changes

### `src/bub/builtin/shell_manager.py`
- Replace hardcoded `/bin/bash` with `shutil.which("bash") or shutil.which("sh")` for cross-platform compatibility (Linux, FreeBSD, macOS).

### `src/skills/telegram/scripts/telegram_send.py`
- Support `--message -` to read message content from stdin, bypassing shell interpretation entirely.
- Backward compatible — `--message 'text'` still works as before.

### `src/skills/telegram/scripts/telegram_edit.py`
- Support `--text -` to read message content from stdin (same approach as `telegram_send.py`).

### `src/skills/telegram/SKILL.md`
- Update all command templates to use heredoc stdin piping (`cat << 'EOF' | ... --message -`).
- Add explicit execution policy rule: **always pass message content via stdin, never inline in shell arguments**.
- This lowers the barrier for smaller models that struggle with shell escaping, while remaining fully compatible with stronger models.

## Test plan
- [x] `uv run ruff check .` passes
- [x] `uv run pytest -q` — all tests pass
- [x] Verified on FreeBSD jail: `shutil.which("bash")` correctly resolves `/usr/local/bin/bash`
- [x] Backward compatible — existing `--message 'text'` / `--text 'text'` usage still works
- [x] Deployed and tested on FreeBSD jail with Telegram gateway