### PR TITLE
fix: type error when constructing RepublicError on error

### DIFF
--- a/src/bub/framework.py
+++ b/src/bub/framework.py
@@ -11,6 +11,7 @@ import typer
 from dotenv import load_dotenv
 from loguru import logger
 from republic import AsyncTapeStore, RepublicError, TapeContext
+from republic.core.errors import ErrorKind
 from republic.tape import TapeStore
 
 from bub.envelope import content_of, field_of, unpack_batch
@@ -146,8 +147,13 @@ class BubFramework:
                 if event.kind == "text":
                     parts.append(str(event.data.get("delta", "")))
                 elif event.kind == "error":
+                    # Turn "kind" to enum type otherwise the RepublicError's __str__ won't work well
+                    data = {
+                        **event.data,
+                        "kind": ErrorKind(event.data.get("kind", "unknown")),
+                    }
                     await self._hook_runtime.notify_error(
-                        stage="run_model", error=RepublicError(**event.data), message=inbound
+                        stage="run_model", error=RepublicError(**data), message=inbound
                     )
             return "".join(parts)
 


### PR DESCRIPTION
Bub won't report the error message on error, the stack trace:

```plaintext
  File "/home/ubuntu/bub/bub/src/bub/framework.py", line 149, in _run_model
    await self._hook_runtime.notify_error(
          │    │             └ <function HookRuntime.notify_error at 0x70a8adf11580>
          │    └ <bub.hook_runtime.HookRuntime object at 0x70a8ae72db20>
          └ <bub.framework.BubFramework object at 0x70a8adf19b20>

> File "/home/ubuntu/bub/bub/src/bub/hook_runtime.py", line 82, in notify_error
    await value
          └ <coroutine object BuiltinImpl.on_error at 0x70a8a7f288c0>

  File "/home/ubuntu/bub/bub/src/bub/builtin/hook_impl.py", line 157, in on_error
    content=f"An error occurred at stage '{stage}': {error}",
                                           │         └ RepublicError(kind='invalid_input', message="openrouter:kimi-k2.5: Error code: 400 - {'id': 'e2d7e711df0a3f112f0bc51ded289ea7...
                                           └ 'run_model'

  File "/home/ubuntu/bub/bub/.venv/lib/python3.12/site-packages/republic/core/errors.py", line 31, in __str__
    return f"[{self.kind.value}] {self.message}"
               │    │             │    └ "openrouter:kimi-k2.5: Error code: 400 - {'id': 'e2d7e711df0a3f112f0bc51ded289ea7', 'error': {'message': 'Request parameters ...
               │    │             └ RepublicError(kind='invalid_input', message="openrouter:kimi-k2.5: Error code: 400 - {'id': 'e2d7e711df0a3f112f0bc51ded289ea7...
               │    └ 'invalid_input'
               └ RepublicError(kind='invalid_input', message="openrouter:kimi-k2.5: Error code: 400 - {'id': 'e2d7e711df0a3f112f0bc51ded289ea7...

AttributeError: 'str' object has no attribute 'value'
```

The reason is that the exception instance was created with "kind" using the wrong type, a str instead of the enum.

This PR fixes this issue by updating the construction statement for the RepublicError type when an error occurs. Another possible solution would be to modify the RepublicError type to accept a raw string type for the "kind" field and do the type conversion inside. Please let me know if this makes more sense.