### PR TITLE
fix: restore CLI chat response display after stream_output refactor

### DIFF
--- a/src/bub/builtin/cli.py
+++ b/src/bub/builtin/cli.py
@@ -83,7 +83,7 @@ def chat(
 
     framework = ctx.ensure_object(BubFramework)
 
-    manager = ChannelManager(framework, enabled_channels=["cli"])
+    manager = ChannelManager(framework, enabled_channels=["cli"], stream_output=True)
     channel = manager.get_channel("cli")
     if channel is None:
         typer.echo("CLI channel not found. Please check your hook implementations.")

--- a/src/bub/channels/manager.py
+++ b/src/bub/channels/manager.py
@@ -39,10 +39,16 @@ class ChannelSettings(BaseSettings):
 
 
 class ChannelManager:
-    def __init__(self, framework: BubFramework, enabled_channels: Collection[str] | None = None) -> None:
+    def __init__(
+        self,
+        framework: BubFramework,
+        enabled_channels: Collection[str] | None = None,
+        stream_output: bool | None = None,
+    ) -> None:
         self.framework = framework
         self._channels: dict[str, Channel] = self.framework.get_channels(self.on_receive)
         self._settings = ChannelSettings()
+        self._stream_output = stream_output if stream_output is not None else self._settings.stream_output
         if enabled_channels is not None:
             self._enabled_channels = list(enabled_channels)
         else:
@@ -139,7 +145,7 @@ class ChannelManager:
         try:
             while True:
                 message = await wait_until_stopped(self._messages.get(), stop_event)
-                task = asyncio.create_task(self.framework.process_inbound(message, self._settings.stream_output))
+                task = asyncio.create_task(self.framework.process_inbound(message, self._stream_output))
                 task.add_done_callback(functools.partial(self._on_task_done, message.session_id))
                 self._ongoing_tasks.setdefault(message.session_id, set()).add(task)
         except asyncio.CancelledError:


### PR DESCRIPTION
The stream_output flag introduced in #170 defaults to False, which bypasses CliChannel.stream_events() and relies on send() for output. Since send() only handled errors, normal responses were silently dropped.

- Force stream_output=True for `bub chat` so streaming remains the primary display path.
- Store stream_output override as an instance variable instead of mutating the settings object.

Made-with: Cursor
