### PR TITLE
fix: enable colored loguru output for terminal display

### DIFF
--- a/src/bub/__main__.py
+++ b/src/bub/__main__.py
@@ -2,22 +2,27 @@
 
 from __future__ import annotations
 
+import sys
+
 import typer
 
 from bub.framework import BubFramework
 
 
 def _instrument_bub() -> None:
+    from loguru import logger
+
     try:
         import logfire
 
         logfire.configure()
     except ImportError:
-        pass
+        logger.remove()
+        logger.add(sys.stderr, colorize=True)
     else:
-        from loguru import logger
-
-        logger.configure(handlers=[logfire.loguru_handler()])
+        logger.remove()
+        logger.add(sys.stderr, colorize=True)
+        logger.add(logfire.loguru_handler())
 
 
 def create_cli_app() -> typer.Typer:

--- a/src/bub/__main__.py
+++ b/src/bub/__main__.py
@@ -12,17 +12,16 @@ from bub.framework import BubFramework
 def _instrument_bub() -> None:
     from loguru import logger
 
+    logger.remove()
+    logger.add(sys.stderr, colorize=True)
+
     try:
         import logfire
 
         logfire.configure()
-    except ImportError:
-        logger.remove()
-        logger.add(sys.stderr, colorize=True)
-    else:
-        logger.remove()
-        logger.add(sys.stderr, colorize=True)
         logger.add(logfire.loguru_handler())
+    except ImportError:
+        pass
 
 
 def create_cli_app() -> typer.Typer:


### PR DESCRIPTION
## Summary

- Explicitly configure a `colorize=True` stderr sink for loguru so that log output is colored when displayed in a terminal
- When logfire is available, the colorized stderr sink is added alongside the logfire handler

## Problem

loguru's default handler does not emit ANSI color codes in certain terminal environments (e.g., when running through subprocess wrappers or non-TTY stdin contexts). This causes log output to lose color formatting.

## Fix

In `_instrument_bub()`, explicitly configure loguru with:
- `logger.remove()` to clear default handlers
- `logger.add(sys.stderr, colorize=True)` to ensure colored output in terminal display
- When logfire is available, add `logfire.loguru_handler()` alongside the colorized sink

This ensures terminal display always has colored output while preserving logfire integration when available.

## Test plan

- [ ] Run `uv run bub gateway` and verify log output has ANSI colors in terminal
- [ ] Verify logfire integration still works when logfire is installed
- [ ] Verify graceful fallback when logfire is not installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)