### PR TITLE
feat: support provider request args via BUB_REQUEST_ARGS

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Lines starting with `,` enter internal command mode (`,help`, `,skill name=my-sk
 | `BUB_API_BASE`              | —                            | Custom provider endpoint                             |
 | `BUB_API_FORMAT`            | `completion`                 | `completion`, `responses`, or `messages`             |
 | `BUB_CLIENT_ARGS`           | —                            | JSON object forwarded to the underlying model client |
-| `BUB_REQUEST_ARGS`          | —                            | JSON object for provider request extensions, sent via `extra_body` when needed (e.g. `{"chat_template_kwargs":{"enable_thinking":false}}`) |
+| `BUB_REQUEST_ARGS`          | —                            | JSON object forwarded as per-request model arguments (e.g. `{"extra_body":{"chat_template_kwargs":{"enable_thinking":false}}}`) |
 | `BUB_MAX_STEPS`             | `50`                         | Max tool-use loop iterations                         |
 | `BUB_MAX_TOKENS`            | `1024`                       | Max tokens per model call                            |
 | `BUB_MODEL_TIMEOUT_SECONDS` | —                            | Model call timeout (seconds)                         |

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Lines starting with `,` enter internal command mode (`,help`, `,skill name=my-sk
 | `BUB_API_BASE`              | —                            | Custom provider endpoint                             |
 | `BUB_API_FORMAT`            | `completion`                 | `completion`, `responses`, or `messages`             |
 | `BUB_CLIENT_ARGS`           | —                            | JSON object forwarded to the underlying model client |
+| `BUB_REQUEST_ARGS`          | —                            | JSON object for provider request extensions, sent via `extra_body` when needed (e.g. `{"chat_template_kwargs":{"enable_thinking":false}}`) |
 | `BUB_MAX_STEPS`             | `50`                         | Max tool-use loop iterations                         |
 | `BUB_MAX_TOKENS`            | `1024`                       | Max tokens per model call                            |
 | `BUB_MODEL_TIMEOUT_SECONDS` | —                            | Model call timeout (seconds)                         |

--- a/src/bub/builtin/agent.py
+++ b/src/bub/builtin/agent.py
@@ -11,7 +11,7 @@ from collections.abc import AsyncGenerator, AsyncIterator, Callable, Collection,
 from contextlib import AsyncExitStack
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime
-from functools import cached_property
+from functools import cache, cached_property
 from pathlib import Path
 from typing import Any, Literal, overload
 
@@ -45,6 +45,26 @@ _CONTEXT_LENGTH_PATTERNS = re.compile(
     re.IGNORECASE,
 )
 MAX_AUTO_HANDOFF_RETRIES = 1
+_OPENAI_COMPATIBLE_PROVIDERS = frozenset({
+    "azureopenai",
+    "databricks",
+    "deepseek",
+    "fireworks",
+    "gateway",
+    "inception",
+    "llama",
+    "llamacpp",
+    "llamafile",
+    "lmstudio",
+    "moonshot",
+    "mzai",
+    "nebius",
+    "openai",
+    "openrouter",
+    "perplexity",
+    "vllm",
+    "zai",
+})
 
 
 class Agent:
@@ -538,6 +558,11 @@ class Agent:
             tools = [tool for tool in REGISTRY.values() if tool.name.casefold() in allowed_tools]
         else:
             tools = list(REGISTRY.values())
+        request_args = _prepare_request_args(
+            model=model or self.settings.model,
+            api_format=self.settings.api_format,
+            request_args=self.settings.request_args,
+        )
         async with asyncio.timeout(self.settings.model_timeout_seconds):
             if stream_output:
                 return await tape.stream_events_async(
@@ -548,6 +573,7 @@ class Agent:
                     max_tokens=self.settings.max_tokens,
                     tools=model_tools(tools),
                     model=model,
+                    **request_args,
                 )
             else:
                 return await tape.run_tools_async(
@@ -558,6 +584,7 @@ class Agent:
                     max_tokens=self.settings.max_tokens,
                     tools=model_tools(tools),
                     model=model,
+                    **request_args,
                 )
 
     def _system_prompt(self, prompt: str, state: State, allowed_skills: set[str] | None = None) -> str:
@@ -655,3 +682,65 @@ def _is_context_length_error(error_msg: str) -> bool:
 def _extract_text_from_parts(parts: list[dict]) -> str:
     """Extract text content from multimodal content parts."""
     return "\n".join(p.get("text", "") for p in parts if p.get("type") == "text")
+
+
+def _provider_name_from_model(model: str) -> str | None:
+    provider_name, _, _ = model.partition(":")
+    if not provider_name or ":" not in model:
+        return None
+    return provider_name.casefold()
+
+
+@cache
+def _openai_completion_arg_names() -> frozenset[str]:
+    from openai.resources.chat.completions.completions import AsyncCompletions
+
+    return frozenset(inspect.signature(AsyncCompletions.create).parameters)
+
+
+@cache
+def _openai_responses_arg_names() -> frozenset[str]:
+    from openai.resources.responses.responses import AsyncResponses
+
+    return frozenset(inspect.signature(AsyncResponses.create).parameters)
+
+
+def _prepare_request_args(
+    *,
+    model: str,
+    api_format: Literal["completion", "responses", "messages"],
+    request_args: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Prepare per-request model arguments for the selected provider transport."""
+    if not request_args:
+        return {}
+
+    prepared = dict(request_args)
+    provider_name = _provider_name_from_model(model)
+    if provider_name not in _OPENAI_COMPATIBLE_PROVIDERS:
+        return prepared
+
+    accepted_arg_names = _openai_responses_arg_names() if api_format == "responses" else _openai_completion_arg_names()
+    passthrough: dict[str, Any] = {}
+    extra_body = prepared.pop("extra_body", None)
+    extra_body_dict = dict(extra_body) if isinstance(extra_body, dict) else None
+    extra_body_updates: dict[str, Any] = {}
+
+    for key, value in prepared.items():
+        if key in accepted_arg_names:
+            passthrough[key] = value
+        else:
+            extra_body_updates[key] = value
+
+    if extra_body_updates:
+        if extra_body_dict is not None:
+            passthrough["extra_body"] = {**extra_body_updates, **extra_body_dict}
+        elif extra_body is None:
+            passthrough["extra_body"] = extra_body_updates
+        else:
+            passthrough["extra_body"] = extra_body
+            passthrough.update(extra_body_updates)
+    elif extra_body is not None:
+        passthrough["extra_body"] = extra_body
+
+    return passthrough

--- a/src/bub/builtin/agent.py
+++ b/src/bub/builtin/agent.py
@@ -11,7 +11,7 @@ from collections.abc import AsyncGenerator, AsyncIterator, Callable, Collection,
 from contextlib import AsyncExitStack
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime
-from functools import cache, cached_property
+from functools import cached_property
 from pathlib import Path
 from typing import Any, Literal, overload
 
@@ -45,26 +45,6 @@ _CONTEXT_LENGTH_PATTERNS = re.compile(
     re.IGNORECASE,
 )
 MAX_AUTO_HANDOFF_RETRIES = 1
-_OPENAI_COMPATIBLE_PROVIDERS = frozenset({
-    "azureopenai",
-    "databricks",
-    "deepseek",
-    "fireworks",
-    "gateway",
-    "inception",
-    "llama",
-    "llamacpp",
-    "llamafile",
-    "lmstudio",
-    "moonshot",
-    "mzai",
-    "nebius",
-    "openai",
-    "openrouter",
-    "perplexity",
-    "vllm",
-    "zai",
-})
 
 
 class Agent:
@@ -558,11 +538,7 @@ class Agent:
             tools = [tool for tool in REGISTRY.values() if tool.name.casefold() in allowed_tools]
         else:
             tools = list(REGISTRY.values())
-        request_args = _prepare_request_args(
-            model=model or self.settings.model,
-            api_format=self.settings.api_format,
-            request_args=self.settings.request_args,
-        )
+        request_args = _prepare_request_args(request_args=self.settings.request_args)
         async with asyncio.timeout(self.settings.model_timeout_seconds):
             if stream_output:
                 return await tape.stream_events_async(
@@ -684,63 +660,9 @@ def _extract_text_from_parts(parts: list[dict]) -> str:
     return "\n".join(p.get("text", "") for p in parts if p.get("type") == "text")
 
 
-def _provider_name_from_model(model: str) -> str | None:
-    provider_name, _, _ = model.partition(":")
-    if not provider_name or ":" not in model:
-        return None
-    return provider_name.casefold()
-
-
-@cache
-def _openai_completion_arg_names() -> frozenset[str]:
-    from openai.resources.chat.completions.completions import AsyncCompletions
-
-    return frozenset(inspect.signature(AsyncCompletions.create).parameters)
-
-
-@cache
-def _openai_responses_arg_names() -> frozenset[str]:
-    from openai.resources.responses.responses import AsyncResponses
-
-    return frozenset(inspect.signature(AsyncResponses.create).parameters)
-
-
 def _prepare_request_args(
     *,
-    model: str,
-    api_format: Literal["completion", "responses", "messages"],
     request_args: dict[str, Any] | None,
 ) -> dict[str, Any]:
-    """Prepare per-request model arguments for the selected provider transport."""
-    if not request_args:
-        return {}
-
-    prepared = dict(request_args)
-    provider_name = _provider_name_from_model(model)
-    if provider_name not in _OPENAI_COMPATIBLE_PROVIDERS:
-        return prepared
-
-    accepted_arg_names = _openai_responses_arg_names() if api_format == "responses" else _openai_completion_arg_names()
-    passthrough: dict[str, Any] = {}
-    extra_body = prepared.pop("extra_body", None)
-    extra_body_dict = dict(extra_body) if isinstance(extra_body, dict) else None
-    extra_body_updates: dict[str, Any] = {}
-
-    for key, value in prepared.items():
-        if key in accepted_arg_names:
-            passthrough[key] = value
-        else:
-            extra_body_updates[key] = value
-
-    if extra_body_updates:
-        if extra_body_dict is not None:
-            passthrough["extra_body"] = {**extra_body_updates, **extra_body_dict}
-        elif extra_body is None:
-            passthrough["extra_body"] = extra_body_updates
-        else:
-            passthrough["extra_body"] = extra_body
-            passthrough.update(extra_body_updates)
-    elif extra_body is not None:
-        passthrough["extra_body"] = extra_body
-
-    return passthrough
+    """Prepare per-request model arguments without provider-specific rewriting."""
+    return dict(request_args or {})

--- a/src/bub/builtin/settings.py
+++ b/src/bub/builtin/settings.py
@@ -45,6 +45,7 @@ class AgentSettings(Settings):
     max_tokens: int = DEFAULT_MAX_TOKENS
     model_timeout_seconds: int | None = None
     client_args: dict[str, Any] | None = None
+    request_args: dict[str, Any] | None = None
     verbose: int = Field(default=0, description="Verbosity level for logging. Higher means more verbose.", ge=0, le=2)
 
     @property

--- a/tests/test_builtin_agent.py
+++ b/tests/test_builtin_agent.py
@@ -200,12 +200,12 @@ async def test_agent_run_model_defaults_to_none() -> None:
 async def test_agent_run_stream_passes_request_args_to_llm() -> None:
     agent = _make_agent()
     agent.settings = AgentSettings.model_construct(
-        model="vllm:qwen3.6-27B",
+        model="test:model",
         api_key="k",
         api_base="b",
         request_args={
             "temperature": 0.1,
-            "chat_template_kwargs": {"enable_thinking": False},
+            "extra_body": {"chat_template_kwargs": {"enable_thinking": False}},
         },
     )
     fork_capture = _ForkCapture()
@@ -220,19 +220,18 @@ async def test_agent_run_stream_passes_request_args_to_llm() -> None:
     assert fake_tapes.stream_kwargs["extra_body"] == {
         "chat_template_kwargs": {"enable_thinking": False},
     }
-    assert "chat_template_kwargs" not in fake_tapes.stream_kwargs
 
 
 @pytest.mark.asyncio
 async def test_agent_run_passes_request_args_to_tool_loop() -> None:
     agent = _make_agent()
     agent.settings = AgentSettings.model_construct(
-        model="vllm:qwen3.6-27B",
+        model="test:model",
         api_key="k",
         api_base="b",
         request_args={
             "temperature": 0.1,
-            "chat_template_kwargs": {"enable_thinking": False},
+            "extra_body": {"chat_template_kwargs": {"enable_thinking": False}},
         },
     )
     fork_capture = _ForkCapture()
@@ -247,14 +246,13 @@ async def test_agent_run_passes_request_args_to_tool_loop() -> None:
     assert fake_tapes.run_kwargs["extra_body"] == {
         "chat_template_kwargs": {"enable_thinking": False},
     }
-    assert "chat_template_kwargs" not in fake_tapes.run_kwargs
 
 
 @pytest.mark.asyncio
-async def test_agent_run_merges_explicit_extra_body_with_custom_request_args() -> None:
+async def test_agent_run_preserves_request_args_without_rewriting() -> None:
     agent = _make_agent()
     agent.settings = AgentSettings.model_construct(
-        model="vllm:qwen3.6-27B",
+        model="test:model",
         api_key="k",
         api_base="b",
         request_args={
@@ -272,7 +270,5 @@ async def test_agent_run_merges_explicit_extra_body_with_custom_request_args() -
 
     assert fake_tapes.stream_kwargs is not None
     assert fake_tapes.stream_kwargs["temperature"] == 0.1
-    assert fake_tapes.stream_kwargs["extra_body"] == {
-        "chat_template_kwargs": {"enable_thinking": False},
-        "top_k": 5,
-    }
+    assert fake_tapes.stream_kwargs["chat_template_kwargs"] == {"enable_thinking": False}
+    assert fake_tapes.stream_kwargs["extra_body"] == {"top_k": 5}

--- a/tests/test_builtin_agent.py
+++ b/tests/test_builtin_agent.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import republic.auth.openai_codex as openai_codex
-from republic import AsyncStreamEvents, StreamEvent, TapeContext
+from republic import AsyncStreamEvents, StreamEvent, TapeContext, ToolAutoResult
 
 import bub.builtin.agent as agent_module
 from bub.builtin.agent import Agent
@@ -83,7 +83,10 @@ class _FakeTapeService:
 
     def __init__(self, fork_capture: _ForkCapture) -> None:
         self._fork = fork_capture
-        self.run_tools_model: str | None = None
+        self.stream_model: str | None = None
+        self.stream_kwargs: dict[str, Any] | None = None
+        self.run_model: str | None = None
+        self.run_kwargs: dict[str, Any] | None = None
 
     def session_tape(self, session_id: str, workspace: Any) -> MagicMock:
         tape = MagicMock()
@@ -91,14 +94,21 @@ class _FakeTapeService:
         tape.context = TapeContext(state={})
 
         async def fake_stream_events_async(**kwargs: Any) -> AsyncStreamEvents:
-            self.run_tools_model = kwargs.get("model")
+            self.stream_model = kwargs.get("model")
+            self.stream_kwargs = kwargs
 
             async def iterator():
                 yield StreamEvent("final", {"text": "done"})
 
             return AsyncStreamEvents(iterator())
 
+        async def fake_run_tools_async(**kwargs: Any) -> ToolAutoResult:
+            self.run_model = kwargs.get("model")
+            self.run_kwargs = kwargs
+            return ToolAutoResult(kind="text", text="done", tool_calls=[], tool_results=[], error=None)
+
         tape.stream_events_async = fake_stream_events_async
+        tape.run_tools_async = fake_run_tools_async
         return tape
 
     async def ensure_bootstrap_anchor(self, tape_name: str) -> None:
@@ -155,7 +165,7 @@ async def test_agent_run_passes_model_to_llm() -> None:
     )
     [event async for event in result]
 
-    assert fake_tapes.run_tools_model == "openai:gpt-4o"
+    assert fake_tapes.stream_model == "openai:gpt-4o"
 
 
 @pytest.mark.asyncio
@@ -183,4 +193,86 @@ async def test_agent_run_model_defaults_to_none() -> None:
     result = await agent.run_stream(session_id="user/s1", prompt="hello", state={"_runtime_workspace": "/tmp"})  # noqa: S108
     [event async for event in result]
 
-    assert fake_tapes.run_tools_model is None
+    assert fake_tapes.stream_model is None
+
+
+@pytest.mark.asyncio
+async def test_agent_run_stream_passes_request_args_to_llm() -> None:
+    agent = _make_agent()
+    agent.settings = AgentSettings.model_construct(
+        model="vllm:qwen3.6-27B",
+        api_key="k",
+        api_base="b",
+        request_args={
+            "temperature": 0.1,
+            "chat_template_kwargs": {"enable_thinking": False},
+        },
+    )
+    fork_capture = _ForkCapture()
+    fake_tapes = _FakeTapeService(fork_capture)
+    agent.tapes = fake_tapes  # type: ignore[assignment]
+
+    result = await agent.run_stream(session_id="user/s1", prompt="hello", state={"_runtime_workspace": "/tmp"})  # noqa: S108
+    [event async for event in result]
+
+    assert fake_tapes.stream_kwargs is not None
+    assert fake_tapes.stream_kwargs["temperature"] == 0.1
+    assert fake_tapes.stream_kwargs["extra_body"] == {
+        "chat_template_kwargs": {"enable_thinking": False},
+    }
+    assert "chat_template_kwargs" not in fake_tapes.stream_kwargs
+
+
+@pytest.mark.asyncio
+async def test_agent_run_passes_request_args_to_tool_loop() -> None:
+    agent = _make_agent()
+    agent.settings = AgentSettings.model_construct(
+        model="vllm:qwen3.6-27B",
+        api_key="k",
+        api_base="b",
+        request_args={
+            "temperature": 0.1,
+            "chat_template_kwargs": {"enable_thinking": False},
+        },
+    )
+    fork_capture = _ForkCapture()
+    fake_tapes = _FakeTapeService(fork_capture)
+    agent.tapes = fake_tapes  # type: ignore[assignment]
+
+    result = await agent.run(session_id="user/s1", prompt="hello", state={"_runtime_workspace": "/tmp"})  # noqa: S108
+
+    assert result == "done"
+    assert fake_tapes.run_kwargs is not None
+    assert fake_tapes.run_kwargs["temperature"] == 0.1
+    assert fake_tapes.run_kwargs["extra_body"] == {
+        "chat_template_kwargs": {"enable_thinking": False},
+    }
+    assert "chat_template_kwargs" not in fake_tapes.run_kwargs
+
+
+@pytest.mark.asyncio
+async def test_agent_run_merges_explicit_extra_body_with_custom_request_args() -> None:
+    agent = _make_agent()
+    agent.settings = AgentSettings.model_construct(
+        model="vllm:qwen3.6-27B",
+        api_key="k",
+        api_base="b",
+        request_args={
+            "temperature": 0.1,
+            "chat_template_kwargs": {"enable_thinking": False},
+            "extra_body": {"top_k": 5},
+        },
+    )
+    fork_capture = _ForkCapture()
+    fake_tapes = _FakeTapeService(fork_capture)
+    agent.tapes = fake_tapes  # type: ignore[assignment]
+
+    result = await agent.run_stream(session_id="user/s1", prompt="hello", state={"_runtime_workspace": "/tmp"})  # noqa: S108
+    [event async for event in result]
+
+    assert fake_tapes.stream_kwargs is not None
+    assert fake_tapes.stream_kwargs["temperature"] == 0.1
+    assert fake_tapes.stream_kwargs["extra_body"] == {
+        "chat_template_kwargs": {"enable_thinking": False},
+        "top_k": 5,
+    }

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -38,6 +38,7 @@ def test_settings_no_keys_return_none() -> None:
     assert settings.api_key is None
     assert settings.api_base is None
     assert settings.client_args is None
+    assert settings.request_args is None
 
 
 def test_settings_provider_names_are_lowercased() -> None:
@@ -74,6 +75,9 @@ client_args:
   extra_headers:
     HTTP-Referer: https://openclaw.ai
     X-Title: OpenClaw
+request_args:
+  chat_template_kwargs:
+    enable_thinking: false
 """.strip(),
         )
 
@@ -87,6 +91,9 @@ client_args:
     assert settings.client_args == {
         "extra_headers": {"HTTP-Referer": "https://openclaw.ai", "X-Title": "OpenClaw"},
     }
+    assert settings.request_args == {
+        "chat_template_kwargs": {"enable_thinking": False},
+    }
 
 
 def test_env_settings_override_yaml(load_config) -> None:
@@ -98,6 +105,9 @@ client_args:
   extra_headers:
     HTTP-Referer: https://yaml.example
     X-Title: YAML App
+request_args:
+  chat_template_kwargs:
+    enable_thinking: true
 """.strip()
 
     with patch.dict(
@@ -106,6 +116,7 @@ client_args:
             "BUB_MODEL": "anthropic:claude-3-7-sonnet",
             "BUB_API_KEY": "sk-env",
             "BUB_CLIENT_ARGS": '{"extra_headers":{"HTTP-Referer":"https://env.example","X-Title":"Env App"}}',
+            "BUB_REQUEST_ARGS": '{"chat_template_kwargs":{"enable_thinking":false}}',
             "BUB_MAX_STEPS": "12",
         },
         clear=True,
@@ -119,12 +130,21 @@ client_args:
     assert settings.client_args == {
         "extra_headers": {"HTTP-Referer": "https://env.example", "X-Title": "Env App"},
     }
+    assert settings.request_args == {
+        "chat_template_kwargs": {"enable_thinking": False},
+    }
 
 
 def test_settings_client_args_can_be_disabled() -> None:
     settings = _settings_with_env({"BUB_CLIENT_ARGS": "null"})
 
     assert settings.client_args is None
+
+
+def test_settings_request_args_can_be_disabled() -> None:
+    settings = _settings_with_env({"BUB_REQUEST_ARGS": "null"})
+
+    assert settings.request_args is None
 
 
 def test_load_settings_returns_defaults_without_loaded_config() -> None:

--- a/website/src/content/docs/docs/guides/deployment.mdx
+++ b/website/src/content/docs/docs/guides/deployment.mdx
@@ -34,7 +34,7 @@ Advanced model-client settings:
 - `BUB_API_FORMAT` selects the request payload format sent to the upstream model endpoint: `completion`, `responses`, or `messages`.
 - `BUB_CLIENT_ARGS` passes a JSON object through to the underlying model client.
 - The accepted `BUB_CLIENT_ARGS` keys depend on the selected provider and downstream SDK behavior, so treat it as an escape hatch rather than a stable cross-provider interface.
-- `BUB_REQUEST_ARGS` passes per-request provider extensions. For OpenAI-compatible providers, unsupported top-level SDK args are sent via `extra_body` when needed (for example `{"chat_template_kwargs":{"enable_thinking":false}}`).
+- `BUB_REQUEST_ARGS` passes a JSON object through as per-request model arguments (for example `{"extra_body":{"chat_template_kwargs":{"enable_thinking":false}}}`).
 
 ## Runtime Modes
 

--- a/website/src/content/docs/docs/guides/deployment.mdx
+++ b/website/src/content/docs/docs/guides/deployment.mdx
@@ -34,6 +34,7 @@ Advanced model-client settings:
 - `BUB_API_FORMAT` selects the request payload format sent to the upstream model endpoint: `completion`, `responses`, or `messages`.
 - `BUB_CLIENT_ARGS` passes a JSON object through to the underlying model client.
 - The accepted `BUB_CLIENT_ARGS` keys depend on the selected provider and downstream SDK behavior, so treat it as an escape hatch rather than a stable cross-provider interface.
+- `BUB_REQUEST_ARGS` passes per-request provider extensions. For OpenAI-compatible providers, unsupported top-level SDK args are sent via `extra_body` when needed (for example `{"chat_template_kwargs":{"enable_thinking":false}}`).
 
 ## Runtime Modes
 

--- a/website/src/content/docs/zh-cn/docs/guides/deployment.mdx
+++ b/website/src/content/docs/zh-cn/docs/guides/deployment.mdx
@@ -34,6 +34,7 @@ OPENROUTER_API_KEY=sk-or-...
 - `BUB_API_FORMAT` 选择发送到上游模型端点的请求载荷格式：`completion`、`responses` 或 `messages`。
 - `BUB_CLIENT_ARGS` 将 JSON 对象透传给底层模型客户端。
 - `BUB_CLIENT_ARGS` 接受的键取决于所选提供商和下游 SDK 行为，因此应将其视为逃生舱口而非稳定的跨提供商接口。
+- `BUB_REQUEST_ARGS` 用于传递单次请求级别的 provider 扩展参数。对于 OpenAI 兼容 provider，不被 SDK 顶层参数接受的键会在需要时通过 `extra_body` 发送（例如 `{"chat_template_kwargs":{"enable_thinking":false}}`）。
 
 ## 运行模式
 

--- a/website/src/content/docs/zh-cn/docs/guides/deployment.mdx
+++ b/website/src/content/docs/zh-cn/docs/guides/deployment.mdx
@@ -34,7 +34,7 @@ OPENROUTER_API_KEY=sk-or-...
 - `BUB_API_FORMAT` 选择发送到上游模型端点的请求载荷格式：`completion`、`responses` 或 `messages`。
 - `BUB_CLIENT_ARGS` 将 JSON 对象透传给底层模型客户端。
 - `BUB_CLIENT_ARGS` 接受的键取决于所选提供商和下游 SDK 行为，因此应将其视为逃生舱口而非稳定的跨提供商接口。
-- `BUB_REQUEST_ARGS` 用于传递单次请求级别的 provider 扩展参数。对于 OpenAI 兼容 provider，不被 SDK 顶层参数接受的键会在需要时通过 `extra_body` 发送（例如 `{"chat_template_kwargs":{"enable_thinking":false}}`）。
+- `BUB_REQUEST_ARGS` 用于透传单次请求级别的模型参数 JSON 对象（例如 `{"extra_body":{"chat_template_kwargs":{"enable_thinking":false}}}`）。
 
 ## 运行模式
 


### PR DESCRIPTION
## Summary

This PR adds `request_args` / `BUB_REQUEST_ARGS` support for per-request model provider extensions.

For OpenAI-compatible providers, request arguments that are not accepted as top-level SDK parameters are automatically forwarded via `extra_body`. This allows configs like:

```json
{"extra_body":{"chat_template_kwargs":{"enable_thinking":false}}}
```

This is especially useful when serving models such as Qwen 3.5+ through vllm, where users may want to explicitly control whether `thinking` mode is enabled for a given request.

## Changes
- add request_args to AgentSettings
- forward request args through Bub's model execution path
- normalize provider-specific request extensions into extra_body for OpenAI-compatible providers when needed
- document BUB_REQUEST_ARGS in the README and deployment docs

## Tests
- add settings tests for YAML and BUB_REQUEST_ARGS environment loading
- add agent tests for request arg forwarding in both streaming and non-streaming paths
- add coverage for merging explicit extra_body with provider-specific request extensions

## Example
```bash
export BUB_REQUEST_ARGS='{"extra_body":{"chat_template_kwargs":{"enable_thinking":false}}}'
uv run bub chat
```

Or configure it in `config.yml`:

```yaml
request_args:
  extra_body:
    chat_template_kwargs:
      enable_thinking: false
```