### PR TITLE
TG proxy fix after explicit get_updates_request

### DIFF
--- a/src/bub/channels/telegram.py
+++ b/src/bub/channels/telegram.py
@@ -173,10 +173,13 @@ class TelegramChannel(Channel):
             len(self._allow_chats),
             bool(proxy),
         )
-        get_updates_request = HTTPXRequest(read_timeout=30)
+        if proxy:
+            get_updates_request = HTTPXRequest(read_timeout=30, proxy=proxy)
+        else:
+            get_updates_request = HTTPXRequest(read_timeout=30)
         builder = Application.builder().token(self._settings.token).get_updates_request(get_updates_request)
         if proxy:
-            builder = builder.proxy(proxy).get_updates_proxy(proxy)
+            builder = builder.proxy(proxy)
         self._app = builder.build()
         self._app.add_handler(CommandHandler("start", self._on_start))
         self._app.add_handler(CommandHandler("bub", self._on_message, has_args=True, block=False))


### PR DESCRIPTION
`.get_updates_proxy(proxy)` and explicit `.get_updates_request(get_updates_request)` cannot coexist.

So need to set proxy on `get_updates_request` directly.

And I noticed telegram message sending are now scripts. And here's the design concern for the scripts:

- they should support proxy too.
- but being general scripts means they should support source proxy from wherever the caller wants
- bub itself also source proxy from multiple locations (BUB_TELEGRAM_PROXY, HTTPS_PROXY, system settings, etc)
- we can have the script support explicit argument for passing proxy, but that's a distraction for the agent's context
- so I prefer to setup bub process's env vars to naturally let the script call inherit the BUB_TELEGRAM_PROXY env var

I'll leave the scripts unchanged for now and the PR in draft for more design input.