### PR TITLE
feat: add turn admission hook

### DIFF
--- a/src/bub/__init__.py
+++ b/src/bub/__init__.py
@@ -13,8 +13,20 @@ from bub.configure import Settings, config, ensure_config
 from bub.framework import DEFAULT_HOME, BubFramework
 from bub.hookspecs import hookimpl
 from bub.tools import tool
+from bub.turn_admission import AdmitDecision, SteeringBuffer, TurnSnapshot
 
-__all__ = ["BubFramework", "Settings", "config", "ensure_config", "home", "hookimpl", "tool"]
+__all__ = [
+    "AdmitDecision",
+    "BubFramework",
+    "Settings",
+    "SteeringBuffer",
+    "TurnSnapshot",
+    "config",
+    "ensure_config",
+    "home",
+    "hookimpl",
+    "tool",
+]
 
 try:
     __version__ = import_module("bub._version").version

--- a/src/bub/channels/manager.py
+++ b/src/bub/channels/manager.py
@@ -15,6 +15,7 @@ from bub.channels.message import ChannelMessage
 from bub.configure import Settings, ensure_config
 from bub.envelope import content_of, field_of
 from bub.framework import BubFramework
+from bub.turn_admission import AdmitDecision, SessionTurnController
 from bub.types import Envelope, MessageHandler
 from bub.utils import wait_until_stopped
 
@@ -57,7 +58,7 @@ class ChannelManager:
         else:
             self._enabled_channels = self._settings.enabled_channels.split(",")
         self._messages = asyncio.Queue[ChannelMessage]()
-        self._ongoing_tasks: dict[str, set[asyncio.Task]] = {}
+        self._session_controllers: dict[str, SessionTurnController] = {}
         self._session_handlers: dict[str, MessageHandler] = {}
 
     async def on_receive(self, message: ChannelMessage) -> None:
@@ -117,7 +118,14 @@ class ChannelManager:
         return channel.stream_events(message, stream)
 
     async def quit(self, session_id: str) -> None:
-        tasks = self._ongoing_tasks.pop(session_id, set())
+        controller = self._session_controllers.get(session_id)
+        if controller is None:
+            self.framework.clear_steering(session_id)
+            logger.info(f"channel.manager quit session_id={session_id}, cancelled 0 tasks")
+            return
+        controller.clear_pending()
+        controller.steering.drain_nowait()
+        tasks = set(controller.active_tasks)
         current_task = asyncio.current_task()
         cancelled_count = 0
         for task in tasks:
@@ -127,6 +135,8 @@ class ChannelManager:
             with contextlib.suppress(asyncio.CancelledError):
                 await task
             cancelled_count += 1
+        controller.active_tasks.difference_update(task for task in tasks if task is not current_task)
+        self._drop_empty_controller(session_id)
         logger.info(f"channel.manager quit session_id={session_id}, cancelled {cancelled_count} tasks")
 
     def enabled_channels(self) -> list[Channel]:
@@ -137,15 +147,132 @@ class ChannelManager:
             channel for name, channel in self._channels.items() if name in self._enabled_channels and channel.enabled
         ]
 
+    def _controller(self, session_id: str) -> SessionTurnController:
+        controller = self._session_controllers.get(session_id)
+        if controller is None:
+            controller = SessionTurnController(session_id=session_id, steering=self.framework.steering(session_id))
+            self._session_controllers[session_id] = controller
+        return controller
+
+    def _drop_empty_controller(self, session_id: str) -> None:
+        controller = self._session_controllers.get(session_id)
+        if controller is None:
+            return
+        if controller.active() or controller.pending_queue or controller.steering.count > 0:
+            return
+        self._session_controllers.pop(session_id, None)
+        self.framework.clear_steering(session_id)
+
     def _on_task_done(self, session_id: str, task: asyncio.Task) -> None:
         if task.cancelled():
             logger.info("channel.manager task cancelled session_id={}", session_id)
         else:
             task.exception()  # to log any exception
-        tasks = self._ongoing_tasks.get(session_id, set())
-        tasks.discard(task)
-        if not tasks:
-            self._ongoing_tasks.pop(session_id, None)
+        controller = self._session_controllers.get(session_id)
+        if controller is None:
+            return
+        controller.active_tasks.discard(task)
+        if not controller.active():
+            controller.promote_steering_to_pending()
+        self._schedule_pending(session_id)
+        self._drop_empty_controller(session_id)
+
+    async def _admit_message(self, message: ChannelMessage) -> bool:
+        try:
+            session_id = await self._resolve_message_session(message)
+        except Exception as exc:
+            logger.exception("channel.manager resolve_session failed")
+            await self.framework._hook_runtime.notify_error(stage="resolve_session", error=exc, message=message)
+            return False
+        controller = self._controller(session_id)
+        try:
+            decision = await self.framework.admit_message(
+                session_id=session_id,
+                message=message,
+                turn=controller.snapshot(),
+            )
+        except Exception as exc:
+            logger.exception("channel.manager admission hook failed")
+            await self.framework._hook_runtime.notify_error(stage="admit_message", error=exc, message=message)
+            return True
+        if decision is None:
+            self._drop_empty_controller(session_id)
+            return True
+        admitted = await self._apply_admission_decision(controller, message, decision)
+        if not admitted or not controller.active():
+            self._drop_empty_controller(session_id)
+        return admitted
+
+    async def _apply_admission_decision(
+        self,
+        controller: SessionTurnController,
+        message: ChannelMessage,
+        decision: AdmitDecision,
+    ) -> bool:
+        action = decision.action
+        if action == "process":
+            return True
+        if action == "drop":
+            logger.info(
+                "channel.manager admission drop session_id={} reason={}",
+                message.session_id,
+                decision.reason,
+            )
+            return False
+        if action == "follow_up":
+            return self._queue_pending(controller, message, decision.reason)
+        if action == "steer":
+            if controller.active():
+                controller.steering.put_nowait(message)
+                logger.info(
+                    "channel.manager admission steer session_id={} reason={}",
+                    message.session_id,
+                    decision.reason,
+                )
+                return False
+            return self._queue_pending(controller, message, decision.reason)
+        logger.warning("channel.manager admission unknown action={} session_id={}", decision.action, message.session_id)
+        return True
+
+    def _queue_pending(
+        self,
+        controller: SessionTurnController,
+        message: ChannelMessage,
+        reason: str | None,
+    ) -> bool:
+        if not controller.active():
+            return True
+        controller.add_pending(message)
+        logger.info(
+            "channel.manager admission follow_up session_id={} pending_count={} reason={}",
+            message.session_id,
+            len(controller.pending_queue),
+            reason,
+        )
+        return False
+
+    def _schedule_message(self, message: ChannelMessage) -> asyncio.Task:
+        controller = self._controller(message.session_id)
+        task = asyncio.create_task(self._run_message(message))
+        task.add_done_callback(functools.partial(self._on_task_done, message.session_id))
+        controller.active_tasks.add(task)
+        return task
+
+    def _schedule_pending(self, session_id: str) -> None:
+        controller = self._session_controllers.get(session_id)
+        if controller is None or controller.active():
+            return
+        message = controller.pop_pending()
+        if message is not None:
+            self._schedule_message(message)
+
+    async def _resolve_message_session(self, message: ChannelMessage) -> str:
+        session_id = await self.framework.resolve_session(message)
+        message.session_id = session_id
+        return session_id
+
+    async def _run_message(self, message: ChannelMessage) -> None:
+        await self.framework.process_inbound(message, self._stream_output)
 
     async def listen_and_run(self) -> None:
         stop_event = asyncio.Event()
@@ -157,9 +284,9 @@ class ChannelManager:
             try:
                 while True:
                     message = await wait_until_stopped(self._messages.get(), stop_event)
-                    task = asyncio.create_task(self.framework.process_inbound(message, self._stream_output))
-                    task.add_done_callback(functools.partial(self._on_task_done, message.session_id))
-                    self._ongoing_tasks.setdefault(message.session_id, set()).add(task)
+                    if not await self._admit_message(message):
+                        continue
+                    self._schedule_message(message)
             except asyncio.CancelledError:
                 logger.info("channel.manager received shutdown signal")
             except Exception:
@@ -172,13 +299,18 @@ class ChannelManager:
 
     async def shutdown(self) -> None:
         count = 0
-        for tasks in self._ongoing_tasks.values():
-            for task in tasks:
+        session_ids = list(self._session_controllers)
+        for controller in list(self._session_controllers.values()):
+            controller.clear_pending()
+            controller.steering.drain_nowait()
+            for task in set(controller.active_tasks):
                 task.cancel()
                 with contextlib.suppress(asyncio.CancelledError):
                     await task
                 count += 1
-        self._ongoing_tasks.clear()
+        self._session_controllers.clear()
+        for session_id in session_ids:
+            self.framework.clear_steering(session_id)
         logger.info(f"channel.manager cancelled {count} in-flight tasks")
         for channel in self.enabled_channels():
             await channel.stop()

--- a/src/bub/framework.py
+++ b/src/bub/framework.py
@@ -6,7 +6,7 @@ import contextlib
 from collections.abc import AsyncGenerator, AsyncIterator, Iterator
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import pluggy
 import typer
@@ -20,6 +20,7 @@ from bub import configure
 from bub.envelope import content_of, field_of, unpack_batch
 from bub.hook_runtime import _SKIP_VALUE, HookRuntime
 from bub.hookspecs import BUB_HOOK_NAMESPACE, BubHookSpecs
+from bub.turn_admission import AdmitDecision, SteeringBuffer, TurnSnapshot
 from bub.types import Envelope, MessageHandler, OutboundChannelRouter, TurnResult
 
 if TYPE_CHECKING:
@@ -48,6 +49,7 @@ class BubFramework:
         self._hook_runtime = HookRuntime(self._plugin_manager)
         self._plugin_status: dict[str, PluginStatus] = {}
         self._outbound_router: OutboundChannelRouter | None = None
+        self._steering_buffers: dict[str, SteeringBuffer] = {}
         self._tape_store: TapeStore | AsyncTapeStore | None = None
         configure.load(self.config_file)
 
@@ -109,12 +111,10 @@ class BubFramework:
         """Run one inbound message through hooks and return turn result."""
 
         try:
-            session_id = await self._hook_runtime.call_first(
-                "resolve_session", message=inbound
-            ) or self._default_session_id(inbound)
+            session_id = await self.resolve_session(inbound)
             if isinstance(inbound, dict):
                 inbound.setdefault("session_id", session_id)
-            state = {"_runtime_workspace": str(self.workspace)}
+            state = {"_runtime_workspace": str(self.workspace), "_runtime_steering": self.steering(session_id)}
             for hook_state in reversed(
                 await self._hook_runtime.call_many("load_state", message=inbound, session_id=session_id)
             ):
@@ -145,6 +145,12 @@ class BubFramework:
             logger.exception("Error processing inbound message")
             await self._hook_runtime.notify_error(stage="turn", error=exc, message=inbound)
             raise
+
+    async def resolve_session(self, message: Envelope) -> str:
+        """Resolve the canonical session id for a message."""
+
+        resolved = await self._hook_runtime.call_first("resolve_session", message=message)
+        return str(resolved or self._default_session_id(message))
 
     async def _run_model(
         self,
@@ -206,6 +212,27 @@ class BubFramework:
     async def quit_via_router(self, session_id: str) -> None:
         if self._outbound_router is not None:
             await self._outbound_router.quit(session_id)
+
+    async def admit_message(self, *, session_id: str, message: Envelope, turn: TurnSnapshot) -> AdmitDecision | None:
+        return cast(
+            "AdmitDecision | None",
+            await self._hook_runtime.call_first(
+                "admit_message",
+                session_id=session_id,
+                message=message,
+                turn=turn,
+            ),
+        )
+
+    def steering(self, session_id: str) -> SteeringBuffer:
+        buffer = self._steering_buffers.get(session_id)
+        if buffer is None:
+            buffer = SteeringBuffer(session_id=session_id)
+            self._steering_buffers[session_id] = buffer
+        return buffer
+
+    def clear_steering(self, session_id: str) -> None:
+        self._steering_buffers.pop(session_id, None)
 
     @staticmethod
     def _default_session_id(message: Envelope) -> str:

--- a/src/bub/hookspecs.py
+++ b/src/bub/hookspecs.py
@@ -8,6 +8,7 @@ import pluggy
 from republic import AsyncStreamEvents, AsyncTapeStore, TapeContext
 from republic.tape import TapeStore
 
+from bub.turn_admission import AdmitDecision, TurnSnapshot
 from bub.types import Envelope, MessageHandler, State
 
 if TYPE_CHECKING:
@@ -106,4 +107,17 @@ class BubHookSpecs:
     @hookspec(firstresult=True)
     def build_tape_context(self) -> TapeContext:
         """Build a tape context for the current session, to be used to build context messages."""
+        raise NotImplementedError
+
+    @hookspec(firstresult=True)
+    def admit_message(
+        self,
+        session_id: str,
+        message: Envelope,
+        turn: TurnSnapshot,
+    ) -> AdmitDecision | None:
+        """Decide how to handle an inbound channel message for a session.
+
+        Return ``None`` to keep Bub's default concurrent scheduling behavior.
+        """
         raise NotImplementedError

--- a/src/bub/turn_admission.py
+++ b/src/bub/turn_admission.py
@@ -1,0 +1,105 @@
+"""Turn admission primitives for channel message scheduling."""
+
+from __future__ import annotations
+
+import asyncio
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Literal
+
+from bub.types import Envelope
+
+TurnAdmissionAction = Literal["process", "drop", "follow_up", "steer"]
+
+
+@dataclass(frozen=True)
+class AdmitDecision:
+    """Decision returned by ``admit_message`` hooks."""
+
+    action: TurnAdmissionAction
+    reason: str | None = None
+
+
+@dataclass(frozen=True)
+class TurnSnapshot:
+    """Snapshot of current session turn state exposed to admission hooks."""
+
+    session_id: str
+    is_running: bool
+    running_count: int
+    pending_count: int
+    steering_count: int
+
+
+@dataclass
+class SteeringBuffer:
+    """Per-session queue for steering messages offered to active turns."""
+
+    session_id: str
+    _queue: deque[Envelope] = field(default_factory=deque, init=False, repr=False)
+
+    def put_nowait(self, message: Envelope) -> None:
+        """Append one message."""
+
+        self._queue.append(message)
+
+    @property
+    def count(self) -> int:
+        return len(self._queue)
+
+    def get_nowait(self) -> Envelope | None:
+        """Return one queued message without waiting."""
+
+        if not self._queue:
+            return None
+        return self._queue.popleft()
+
+    def drain_nowait(self) -> list[Envelope]:
+        """Drain steering input and acknowledge ownership of those messages."""
+
+        messages = list(self._queue)
+        self._queue.clear()
+        return messages
+
+
+@dataclass
+class SessionTurnController:
+    """Per-session runtime queues used by ``ChannelManager``."""
+
+    session_id: str
+    steering: SteeringBuffer
+    active_tasks: set[asyncio.Task] = field(default_factory=set)
+    pending_queue: deque[Envelope] = field(default_factory=deque)
+
+    def active(self) -> set[asyncio.Task]:
+        return {task for task in self.active_tasks if not task.done()}
+
+    def snapshot(self) -> TurnSnapshot:
+        running_count = len(self.active())
+        return TurnSnapshot(
+            session_id=self.session_id,
+            is_running=running_count > 0,
+            running_count=running_count,
+            pending_count=len(self.pending_queue),
+            steering_count=self.steering.count,
+        )
+
+    def add_pending(self, message: Envelope) -> bool:
+        self.pending_queue.append(message)
+        return True
+
+    def add_pending_left(self, message: Envelope) -> bool:
+        self.pending_queue.appendleft(message)
+        return True
+
+    def pop_pending(self) -> Envelope | None:
+        if not self.pending_queue:
+            return None
+        return self.pending_queue.popleft()
+
+    def clear_pending(self) -> None:
+        self.pending_queue.clear()
+
+    def promote_steering_to_pending(self) -> None:
+        for message in reversed(self.steering.drain_nowait()):
+            self.add_pending_left(message)

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -16,6 +16,7 @@ from bub.channels.handler import BufferedMessageHandler
 from bub.channels.manager import ChannelManager
 from bub.channels.message import ChannelMessage
 from bub.channels.telegram import BubMessageFilter, TelegramChannel, TelegramMessageParser
+from bub.turn_admission import AdmitDecision, SessionTurnController, SteeringBuffer
 
 
 def _load_channel_config(
@@ -66,6 +67,11 @@ class FakeFramework:
         self._channels = channels
         self.router = None
         self.process_calls: list[tuple[ChannelMessage, bool]] = []
+        self.admission_decisions: list[AdmitDecision | None] = []
+        self.admission_calls: list[tuple[str, ChannelMessage, object]] = []
+        self._steering_buffers: dict[str, SteeringBuffer] = {}
+        self.resolved_sessions: dict[str, str] = {}
+        self._hook_runtime = SimpleNamespace(notify_error=self._notify_error)
         self.running_entries = 0
         self.running_exits = 0
 
@@ -89,6 +95,28 @@ class FakeFramework:
         stop_event = getattr(self, "_stop_event", None)
         if stop_event is not None:
             stop_event.set()
+        return None
+
+    async def admit_message(self, *, session_id: str, message: ChannelMessage, turn):
+        self.admission_calls.append((session_id, message, turn))
+        if self.admission_decisions:
+            return self.admission_decisions.pop(0)
+        return None
+
+    async def resolve_session(self, message: ChannelMessage) -> str:
+        return self.resolved_sessions.get(message.session_id, message.session_id)
+
+    def steering(self, session_id: str) -> SteeringBuffer:
+        buffer = self._steering_buffers.get(session_id)
+        if buffer is None:
+            buffer = SteeringBuffer(session_id=session_id)
+            self._steering_buffers[session_id] = buffer
+        return buffer
+
+    def clear_steering(self, session_id: str) -> None:
+        self._steering_buffers.pop(session_id, None)
+
+    async def _notify_error(self, *, stage: str, error: Exception, message: ChannelMessage | None) -> None:
         return None
 
 
@@ -264,7 +292,7 @@ async def test_channel_manager_shutdown_cancels_tasks_and_stops_enabled_channels
         await asyncio.sleep(10)
 
     task = asyncio.create_task(never_finish())
-    manager._ongoing_tasks["telegram:chat"] = {task}
+    manager._controller("telegram:chat").active_tasks = {task}
 
     await manager.shutdown()
 
@@ -343,15 +371,15 @@ async def test_channel_manager_quit_cancels_only_matching_session_tasks(load_con
 
     target_task = asyncio.create_task(never_finish())
     other_task = asyncio.create_task(never_finish())
-    manager._ongoing_tasks["session:target"] = {target_task}
-    manager._ongoing_tasks["session:other"] = {other_task}
+    manager._controller("session:target").active_tasks = {target_task}
+    manager._controller("session:other").active_tasks = {other_task}
 
     await manager.quit("session:target")
 
     assert target_task.cancelled()
-    assert "session:target" not in manager._ongoing_tasks
+    assert "session:target" not in manager._session_controllers
     assert other_task.cancelled() is False
-    assert manager._ongoing_tasks["session:other"] == {other_task}
+    assert manager._session_controllers["session:other"].active_tasks == {other_task}
 
     other_task.cancel()
     with contextlib.suppress(asyncio.CancelledError):
@@ -369,13 +397,14 @@ async def test_channel_manager_quit_skips_current_task(load_config) -> None:
     current_task = asyncio.current_task()
     assert current_task is not None
     target_task = asyncio.create_task(never_finish())
-    manager._ongoing_tasks["session:target"] = {current_task, target_task}
+    controller = manager._controller("session:target")
+    controller.active_tasks = {current_task, target_task}
 
     await manager.quit("session:target")
 
     assert current_task.cancelled() is False
     assert target_task.cancelled()
-    assert "session:target" not in manager._ongoing_tasks
+    assert controller.active_tasks == {current_task}
 
 
 @pytest.mark.asyncio
@@ -387,14 +416,195 @@ async def test_channel_manager_done_callback_handles_cancelled_task(load_config)
         await asyncio.sleep(10)
 
     task = asyncio.create_task(never_finish())
-    manager._ongoing_tasks["session:target"] = {task}
+    manager._controller("session:target").active_tasks = {task}
     task.cancel()
     with contextlib.suppress(asyncio.CancelledError):
         await task
 
     manager._on_task_done("session:target", task)
 
-    assert "session:target" not in manager._ongoing_tasks
+    assert "session:target" not in manager._session_controllers
+
+
+@pytest.mark.asyncio
+async def test_channel_manager_admission_default_keeps_concurrent_processing(load_config) -> None:
+    _load_channel_config(load_config, enabled_channels="telegram")
+    framework = FakeFramework({"telegram": FakeChannel("telegram")})
+    manager = ChannelManager(framework, enabled_channels=["telegram"])
+
+    async def never_finish() -> None:
+        await asyncio.sleep(10)
+
+    active = asyncio.create_task(never_finish())
+    manager._controller("telegram:chat").active_tasks = {active}
+
+    admitted = await manager._admit_message(_message("second"))
+
+    assert admitted is True
+    session_id, message, turn = framework.admission_calls[0]
+    assert session_id == "telegram:chat"
+    assert message.content == "second"
+    assert turn.is_running is True
+    assert turn.running_count == 1
+    assert turn.pending_count == 0
+    assert turn.steering_count == 0
+
+    active.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await active
+
+
+@pytest.mark.asyncio
+async def test_channel_manager_admission_uses_resolved_session_for_control(load_config) -> None:
+    _load_channel_config(load_config, enabled_channels="telegram")
+    framework = FakeFramework({"telegram": FakeChannel("telegram")})
+    framework.resolved_sessions["telegram:raw"] = "tenant:canonical"
+    framework.admission_decisions.append(AdmitDecision("follow_up", reason="serial"))
+    manager = ChannelManager(framework, enabled_channels=["telegram"])
+
+    async def never_finish() -> None:
+        await asyncio.sleep(10)
+
+    active = asyncio.create_task(never_finish())
+    manager._controller("tenant:canonical").active_tasks = {active}
+
+    admitted = await manager._admit_message(_message("second", session_id="telegram:raw"))
+
+    assert admitted is False
+    assert framework.admission_calls[0][0] == "tenant:canonical"
+    assert "telegram:raw" not in manager._session_controllers
+    assert [message.content for message in manager._session_controllers["tenant:canonical"].pending_queue] == ["second"]
+
+    active.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await active
+
+
+@pytest.mark.asyncio
+async def test_channel_manager_admission_drop_discards_message(load_config) -> None:
+    _load_channel_config(load_config, enabled_channels="telegram")
+    framework = FakeFramework({"telegram": FakeChannel("telegram")})
+    framework.admission_decisions.append(AdmitDecision("drop", reason="busy"))
+    manager = ChannelManager(framework, enabled_channels=["telegram"])
+
+    async def never_finish() -> None:
+        await asyncio.sleep(10)
+
+    active = asyncio.create_task(never_finish())
+    manager._controller("telegram:chat").active_tasks = {active}
+
+    admitted = await manager._admit_message(_message("drop me"))
+
+    assert admitted is False
+    assert not manager._session_controllers["telegram:chat"].pending_queue
+
+    active.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await active
+
+
+@pytest.mark.asyncio
+async def test_channel_manager_admission_follow_up_queues_pending_message(load_config) -> None:
+    _load_channel_config(load_config, enabled_channels="telegram")
+    framework = FakeFramework({"telegram": FakeChannel("telegram")})
+    framework.admission_decisions.append(AdmitDecision("follow_up", reason="serial"))
+    manager = ChannelManager(framework, enabled_channels=["telegram"])
+
+    async def never_finish() -> None:
+        await asyncio.sleep(10)
+
+    active = asyncio.create_task(never_finish())
+    manager._controller("telegram:chat").active_tasks = {active}
+
+    admitted = await manager._admit_message(_message("queued"))
+
+    assert admitted is False
+    assert [message.content for message in manager._session_controllers["telegram:chat"].pending_queue] == ["queued"]
+
+    active.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await active
+
+
+@pytest.mark.asyncio
+async def test_channel_manager_admission_steer_promotes_undrained_messages_to_pending(load_config) -> None:
+    _load_channel_config(load_config, enabled_channels="telegram")
+    framework = FakeFramework({"telegram": FakeChannel("telegram")})
+    framework.admission_decisions.extend([
+        AdmitDecision("steer", reason="correction"),
+        AdmitDecision("steer", reason="correction"),
+    ])
+    manager = ChannelManager(framework, enabled_channels=["telegram"])
+
+    done = asyncio.create_task(asyncio.sleep(0))
+    controller = manager._controller("telegram:chat")
+    controller.active_tasks = {done}
+    controller.add_pending(_message("already waiting"))
+
+    admitted = await manager._admit_message(_message("actually do this"))
+    admitted_again = await manager._admit_message(_message("then this"))
+    await done
+    manager._on_task_done("telegram:chat", done)
+    for _ in range(10):
+        if len(framework.process_calls) == 3:
+            break
+        await asyncio.sleep(0)
+
+    assert admitted is False
+    assert admitted_again is False
+    assert [message.content for message, _ in framework.process_calls] == [
+        "actually do this",
+        "then this",
+        "already waiting",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_channel_manager_admission_steer_drain_acknowledges_ownership(load_config) -> None:
+    _load_channel_config(load_config, enabled_channels="telegram")
+    framework = FakeFramework({"telegram": FakeChannel("telegram")})
+    framework.admission_decisions.append(AdmitDecision("steer", reason="correction"))
+    manager = ChannelManager(framework, enabled_channels=["telegram"])
+
+    done = asyncio.create_task(asyncio.sleep(0))
+    controller = manager._controller("telegram:chat")
+    controller.active_tasks = {done}
+
+    admitted = await manager._admit_message(_message("consume me"))
+    drained = framework.steering("telegram:chat").drain_nowait()
+    await done
+    manager._on_task_done("telegram:chat", done)
+
+    assert admitted is False
+    assert [message.content for message in drained] == ["consume me"]
+    assert framework.process_calls == []
+
+
+def test_turn_admission_queues_preserve_messages_without_capacity_policy() -> None:
+    steering = SteeringBuffer(session_id="telegram:chat")
+
+    steering.put_nowait(_message("one"))
+    steering.put_nowait(_message("two"))
+    steering.put_nowait(_message("three with a long body"))
+    drained_one = steering.get_nowait()
+    assert drained_one is not None
+    assert drained_one.content == "one"
+    assert [message.content for message in steering.drain_nowait()] == ["two", "three with a long body"]
+
+    controller = SessionTurnController(session_id="telegram:chat", steering=SteeringBuffer(session_id="telegram:chat"))
+
+    controller.add_pending(_message("one"))
+    controller.add_pending(_message("two"))
+    controller.add_pending(_message("three with a long body"))
+    assert [message.content for message in controller.pending_queue] == ["one", "two", "three with a long body"]
+
+    controller.add_pending_left(_message("priority"))
+    assert [message.content for message in controller.pending_queue] == [
+        "priority",
+        "one",
+        "two",
+        "three with a long body",
+    ]
 
 
 def test_cli_channel_normalize_input_prefixes_shell_commands() -> None:

--- a/tests/test_framework.py
+++ b/tests/test_framework.py
@@ -20,6 +20,7 @@ from bub.channels.telegram import TelegramSettings
 from bub.configure import ensure_config
 from bub.framework import BubFramework
 from bub.hookspecs import hookimpl
+from bub.turn_admission import AdmitDecision, SteeringBuffer, TurnSnapshot
 
 
 def make_named_channel(name: str, label: str) -> Channel:
@@ -282,6 +283,54 @@ async def test_process_inbound_defaults_to_non_streaming_run_model() -> None:
 
     assert result.model_output == "plain-text"
     assert saved_outputs == ["plain-text"]
+
+
+@pytest.mark.asyncio
+async def test_process_inbound_exposes_runtime_steering_handle() -> None:
+    framework = BubFramework()
+    observed_state: dict[str, Any] = {}
+
+    class SteeringAwarePlugin:
+        @hookimpl
+        async def run_model(self, prompt, session_id, state) -> str:
+            observed_state.update(state)
+            return "ok"
+
+    framework._plugin_manager.register(SteeringAwarePlugin(), name="steering-aware")
+
+    result = await framework.process_inbound({"session_id": "session", "content": "hi"})
+
+    assert result.model_output == "ok"
+    assert isinstance(observed_state["_runtime_steering"], SteeringBuffer)
+    assert observed_state["_runtime_steering"].session_id == "session"
+
+
+@pytest.mark.asyncio
+async def test_framework_admit_message_calls_hook_with_snapshot() -> None:
+    framework = BubFramework()
+
+    class AdmissionPlugin:
+        @hookimpl
+        def admit_message(self, session_id, message, turn):
+            assert session_id == "session"
+            assert message["content"] == "hello"
+            assert turn.pending_count == 1
+            return AdmitDecision("follow_up", reason="busy")
+
+    framework._plugin_manager.register(AdmissionPlugin(), name="admission")
+    decision = await framework.admit_message(
+        session_id="session",
+        message={"content": "hello"},
+        turn=TurnSnapshot(
+            session_id="session",
+            is_running=True,
+            running_count=1,
+            pending_count=1,
+            steering_count=0,
+        ),
+    )
+
+    assert decision == AdmitDecision("follow_up", reason="busy")
 
 
 @pytest.mark.asyncio

--- a/website/src/content/docs/docs/reference/hooks.mdx
+++ b/website/src/content/docs/docs/reference/hooks.mdx
@@ -30,6 +30,7 @@ For the *why* and *how* of each stage see [Turn pipeline](/docs/concepts/turn-pi
 | `provide_tape_store` | firstresult | `() -> TapeStore \| AsyncTapeStore` | tape store | `BubFramework.running()` | Resolved once when the runtime scope opens; sync/async iterators are entered as context managers. |
 | `provide_channels` | sync-only consumer (deduped) | `(message_handler: MessageHandler) -> list[Channel]` | channels | `BubFramework.get_channels` (`call_many_sync`) | Channels are deduplicated by `Channel.name`; the first channel seen in hook priority order wins. |
 | `build_tape_context` | firstresult | `() -> TapeContext` | tape context | `BubFramework.build_tape_context` (`call_first_sync`) | Sync-only; awaitable returns are skipped. |
+| `admit_message` | firstresult | `(session_id, message, turn) -> AdmitDecision \| None` | turn admission decision | `ChannelManager` | Runs before channel scheduling. `None` keeps default concurrent scheduling; decision types are listed in [Types](/docs/reference/types/#turn-admission-types). |
 
 ## How hooks are invoked
 

--- a/website/src/content/docs/docs/reference/types.mdx
+++ b/website/src/content/docs/docs/reference/types.mdx
@@ -51,7 +51,7 @@ Normalizes one `render_outbound` return value to a list. `None` → `[]`; `list`
 type State = dict[str, Any]
 ```
 
-The per-turn state dict. The framework seeds it with `_runtime_workspace` and merges the results of every `load_state` hook before the model call. The same dict is passed to `build_prompt`, `run_model[_stream]`, `save_state`, `render_outbound`, and `system_prompt`.
+The per-turn state dict. The framework seeds it with `_runtime_workspace` and `_runtime_steering`, then merges the results of every `load_state` hook before the model call. The same dict is passed to `build_prompt`, `run_model[_stream]`, `save_state`, `render_outbound`, and `system_prompt`.
 
 ## `MessageHandler`
 
@@ -94,6 +94,42 @@ class TurnResult:
 ```
 
 Returned by `BubFramework.process_inbound`. `prompt` is the resolved prompt. The source annotation is currently `str`, but a `build_prompt` hook may return multimodal content parts and the runtime preserves that list. `outbounds` is the flattened result of every `render_outbound` impl.
+
+## Turn Admission Types
+
+These types are exported from `bub` and defined in `src/bub/turn_admission.py`.
+
+```python
+@dataclass(frozen=True)
+class AdmitDecision:
+    action: Literal["process", "drop", "follow_up", "steer"]
+    reason: str | None = None
+```
+
+```python
+@dataclass(frozen=True)
+class TurnSnapshot:
+    session_id: str
+    is_running: bool
+    running_count: int
+    pending_count: int
+    steering_count: int
+```
+
+`admit_message` implementations return `AdmitDecision` to tell the channel manager whether to process immediately, drop, queue as follow-up input, or steer one inbound message.
+
+```python
+@dataclass
+class SteeringBuffer:
+    session_id: str
+
+    @property
+    def count(self) -> int: ...
+    def get_nowait(self) -> Envelope | None: ...
+    def drain_nowait(self) -> list[Envelope]: ...
+```
+
+`SteeringBuffer` is exposed to model hooks as `state["_runtime_steering"]`. `get_nowait()` removes one message; `drain_nowait()` removes all currently queued messages. Returned messages are owned by the model hook and will not be replayed.
 
 ## `Channel`
 
@@ -159,6 +195,11 @@ class BubFramework:
     def get_tape_store(self) -> TapeStore | AsyncTapeStore | None: ...
     def get_system_prompt(self, prompt: str | list[dict], state: dict[str, Any]) -> str: ...
     def hook_report(self) -> dict[str, list[str]]: ...
+    async def admit_message(
+        self, *, session_id: str, message: Envelope, turn: TurnSnapshot
+    ) -> AdmitDecision | None: ...
+    def steering(self, session_id: str) -> SteeringBuffer: ...
+    def clear_steering(self, session_id: str) -> None: ...
 
     @contextlib.asynccontextmanager
     async def running(self) -> AsyncGenerator[contextlib.AsyncExitStack, None]: ...
@@ -179,6 +220,9 @@ class BubFramework:
 | `get_tape_store()` | Return the tape store entered by `running()`, or `None` outside the scope. |
 | `get_system_prompt(prompt, state)` | Run `system_prompt` impls (sync), reverse, and join non-empty results with `\n\n`. |
 | `hook_report()` | Map hook name → discovered adapter names. Backs `bub hooks`; read the hook reference before treating this order as runtime precedence. |
+| `admit_message(...)` | Call the `admit_message` hook and return the selected decision. Used by `ChannelManager`. |
+| `steering(session_id)` | Return the per-session steering buffer exposed to model hooks. |
+| `clear_steering(session_id)` | Clear an idle session's steering buffer. |
 | `running()` | Async context manager; resolves `provide_tape_store` once and binds the resulting store for the duration. |
 | `bind_outbound_router(router)` | Attach (or detach with `None`) the `OutboundChannelRouter`. The `ChannelManager` calls this on start/stop. |
 | `build_tape_context()` | Sync-call `build_tape_context` and return the resulting `TapeContext`. |
@@ -193,7 +237,10 @@ From `src/bub/__init__.py`:
 | Name | Kind | Description |
 | --- | --- | --- |
 | `BubFramework` | class | Framework runtime (above). |
+| `AdmitDecision` | dataclass | Decision returned by `admit_message`. |
 | `Settings` | class | Base class for plugin settings (re-exported from `bub.configure`). |
+| `SteeringBuffer` | dataclass | Per-session steering queue handle exposed to model hooks. |
+| `TurnSnapshot` | dataclass | Snapshot passed to `admit_message`. |
 | `config` | decorator | `@config(name="...")` registers a settings class for YAML/env validation. |
 | `ensure_config` | function | `ensure_config(SettingsCls)` — return the singleton instance for that class. |
 | `home` | `Path` (lazy attr) | `Path(BUB_HOME)` if set, else `~/.bub`. |

--- a/website/src/content/docs/zh-cn/docs/reference/hooks.mdx
+++ b/website/src/content/docs/zh-cn/docs/reference/hooks.mdx
@@ -30,6 +30,7 @@ description: BubHookSpecs 中每个钩子的类型、签名、返回值与调用
 | `provide_tape_store` | firstresult | `() -> TapeStore \| AsyncTapeStore` | tape store | `BubFramework.running()` | 仅在 runtime 作用域开启时解析一次;返回同步或异步迭代器时会被作为 context manager 进入。 |
 | `provide_channels` | sync-only consumer (deduped) | `(message_handler: MessageHandler) -> list[Channel]` | channels | `BubFramework.get_channels` (`call_many_sync`) | 按 `Channel.name` 去重；在钩子优先级顺序中最先出现的 channel 胜出。 |
 | `build_tape_context` | firstresult | `() -> TapeContext` | tape context | `BubFramework.build_tape_context` (`call_first_sync`) | 仅同步;awaitable 返回会被跳过。 |
+| `admit_message` | firstresult | `(session_id, message, turn) -> AdmitDecision \| None` | turn admission decision | `ChannelManager` | 调度 channel message 前调用。返回 `None` 保持默认并发调度；decision 类型见 [类型](/zh-cn/docs/reference/types/#turn-admission-类型)。 |
 
 ## 钩子如何被调用
 

--- a/website/src/content/docs/zh-cn/docs/reference/types.mdx
+++ b/website/src/content/docs/zh-cn/docs/reference/types.mdx
@@ -51,7 +51,7 @@ def unpack_batch(batch: Any) -> list[Envelope]
 type State = dict[str, Any]
 ```
 
-per-turn 的 state dict。框架先以 `_runtime_workspace` 初始化,再合并所有 `load_state` 钩子的结果,然后才调用模型。同一个 dict 会被传给 `build_prompt`、`run_model[_stream]`、`save_state`、`render_outbound` 与 `system_prompt`。
+per-turn 的 state dict。框架先以 `_runtime_workspace` 与 `_runtime_steering` 初始化,再合并所有 `load_state` 钩子的结果,然后才调用模型。同一个 dict 会被传给 `build_prompt`、`run_model[_stream]`、`save_state`、`render_outbound` 与 `system_prompt`。
 
 ## `MessageHandler`
 
@@ -94,6 +94,42 @@ class TurnResult:
 ```
 
 `BubFramework.process_inbound` 的返回值。`prompt` 是解析后的 prompt。源码标注当前仍是 `str`，但 `build_prompt` hook 可以返回多模态内容片段列表，运行时会保留这个 list。`outbounds` 是所有 `render_outbound` 实现结果的扁平拼接。
+
+## Turn Admission 类型
+
+这些类型从 `bub` 导出,定义在 `src/bub/turn_admission.py`。
+
+```python
+@dataclass(frozen=True)
+class AdmitDecision:
+    action: Literal["process", "drop", "follow_up", "steer"]
+    reason: str | None = None
+```
+
+```python
+@dataclass(frozen=True)
+class TurnSnapshot:
+    session_id: str
+    is_running: bool
+    running_count: int
+    pending_count: int
+    steering_count: int
+```
+
+`admit_message` 实现返回 `AdmitDecision`,告诉 channel manager 对单条 inbound message 立即 process、drop、作为 follow-up input 排队,或 steer。
+
+```python
+@dataclass
+class SteeringBuffer:
+    session_id: str
+
+    @property
+    def count(self) -> int: ...
+    def get_nowait(self) -> Envelope | None: ...
+    def drain_nowait(self) -> list[Envelope]: ...
+```
+
+`SteeringBuffer` 会以 `state["_runtime_steering"]` 暴露给 model hooks。`get_nowait()` 取出一条;`drain_nowait()` 取出当前全部 queued messages。返回的消息由 model hook 接管,不会重放。
 
 ## `Channel`
 
@@ -159,6 +195,11 @@ class BubFramework:
     def get_tape_store(self) -> TapeStore | AsyncTapeStore | None: ...
     def get_system_prompt(self, prompt: str | list[dict], state: dict[str, Any]) -> str: ...
     def hook_report(self) -> dict[str, list[str]]: ...
+    async def admit_message(
+        self, *, session_id: str, message: Envelope, turn: TurnSnapshot
+    ) -> AdmitDecision | None: ...
+    def steering(self, session_id: str) -> SteeringBuffer: ...
+    def clear_steering(self, session_id: str) -> None: ...
 
     @contextlib.asynccontextmanager
     async def running(self) -> AsyncGenerator[contextlib.AsyncExitStack, None]: ...
@@ -179,6 +220,9 @@ class BubFramework:
 | `get_tape_store()` | 返回 `running()` 中启用的 tape store;在作用域之外返回 `None`。 |
 | `get_system_prompt(prompt, state)` | 同步调用 `system_prompt` 实现,反转后用 `\n\n` 拼接非空片段。 |
 | `hook_report()` | 返回 hook 名 → 已发现的 adapter 列表。`bub hooks` 的数据来源；不要只根据该输出顺序推断运行时优先级。 |
+| `admit_message(...)` | 调用 `admit_message` hook 并返回选中的 decision。由 `ChannelManager` 使用。 |
+| `steering(session_id)` | 返回暴露给 model hooks 的 per-session steering buffer。 |
+| `clear_steering(session_id)` | 清除 idle session 的 steering buffer。 |
 | `running()` | 异步 context manager;一次性解析 `provide_tape_store` 并在作用域内绑定 tape store。 |
 | `bind_outbound_router(router)` | 绑定(或传 `None` 解绑)`OutboundChannelRouter`。`ChannelManager` 在启停时调用。 |
 | `build_tape_context()` | 同步调用 `build_tape_context` 并返回 `TapeContext`。 |
@@ -193,7 +237,10 @@ class BubFramework:
 | 名称 | 类型 | 描述 |
 | --- | --- | --- |
 | `BubFramework` | class | 框架运行时(见上)。 |
+| `AdmitDecision` | dataclass | `admit_message` 返回的 decision。 |
 | `Settings` | class | 插件配置基类(从 `bub.configure` 重新导出)。 |
+| `SteeringBuffer` | dataclass | 暴露给 model hooks 的 per-session steering queue handle。 |
+| `TurnSnapshot` | dataclass | 传给 `admit_message` 的快照。 |
 | `config` | decorator | `@config(name="...")` 注册一个用于 YAML/env 验证的配置类。 |
 | `ensure_config` | function | `ensure_config(SettingsCls)` —— 返回该类的单例实例。 |
 | `home` | `Path`(惰性属性) | `BUB_HOME` 已设置时为 `Path(BUB_HOME)`,否则为 `~/.bub`。 |


### PR DESCRIPTION
## Motivation

`ChannelManager` currently schedules each inbound channel message as a new turn immediately. The default concurrent behavior is simple, but plugins do not have a hook to decide whether the next message for an already-active session should be processed now, queued as follow-up input, dropped, or offered to the running turn as steering input.

This PR adds an optional scheduling decision point while keeping the default behavior unchanged.

## Design

Add a new first-result hook:

```python
admit_message(session_id, message, turn) -> AdmitDecision | None
```

`None` means no decision; if every implementation returns `None`, Bub keeps the current default concurrent scheduling behavior.

`AdmitDecision.action` supports four literal actions:

- `"process"`: schedule immediately
- `"drop"`: discard explicitly
- `"follow_up"`: queue as follow-up input after the active turn finishes
- `"steer"`: enqueue as steering input for model hooks to consume via `state["_runtime_steering"]`

`SteeringBuffer` is exposed to `run_model` as a thin runtime API. For now it supports destructive consumption only: `get_nowait()` for one message and `drain_nowait()` for all currently queued steering messages.

Undrained steering messages are promoted to the front of the follow-up queue when the active turn finishes, preserving FIFO order.

## Scope

- admission only applies to the `ChannelManager` path; direct `process_inbound()` calls are unaffected
- `admit_message` does not route messages to a specific forked tape/thread; steering selection and consumption are left to the `run_model` / agent loop implementation
- Bub does not apply size, count, rate, or capacity limits to admission queues; plugins that need such policy can return `"drop"` explicitly
- builtin agent steering consumption and whether turn cancellation should become a framework capability can be discussed separately

## Verification

- `uv run pytest -q`
- `uv run ruff check .`
- `uv run mypy src`