### PR TITLE
fix: treat entry kinds as plain strings and expand user in BUB_HOME

### DIFF
--- a/src/bub/__init__.py
+++ b/src/bub/__init__.py
@@ -44,6 +44,6 @@ if TYPE_CHECKING:
 def __getattr__(name: str):
     if name == "home":
         if "BUB_HOME" in os.environ:
-            return Path(os.environ["BUB_HOME"])
+            return Path(os.path.expanduser(os.environ["BUB_HOME"]))
         return DEFAULT_HOME
     raise AttributeError(f"module {__name__} has no attribute {name}")

--- a/src/bub/builtin/store.py
+++ b/src/bub/builtin/store.py
@@ -23,7 +23,6 @@ from bub.tape import (
     TapeQuery,
     TapeStore,
     is_async_tape_store,
-    is_tape_entry_kind,
 )
 from bub.utils import get_entry_text
 
@@ -319,7 +318,7 @@ class TapeFile:
         meta = payload.get("meta")
         if not isinstance(entry_id, int):
             return None
-        if not is_tape_entry_kind(kind):
+        if not isinstance(kind, str):
             return None
         if not isinstance(entry_payload, dict):
             return None

--- a/src/bub/builtin/tools.py
+++ b/src/bub/builtin/tools.py
@@ -13,7 +13,6 @@ from pydantic import BaseModel, Field
 
 from bub.builtin.shell_manager import shell_manager
 from bub.skills import discover_skills
-from bub.tape import TapeEntryKind
 from bub.tools import REGISTRY, Tool, ToolContext, tool
 
 if TYPE_CHECKING:
@@ -136,7 +135,7 @@ class SearchInput(BaseModel):
     limit: int = Field(20, description="Maximum number of search results to return.")
     start: str | None = Field(None, description="Optional start date to filter entries (ISO format).")
     end: str | None = Field(None, description="Optional end date to filter entries (ISO format).")
-    kinds: list[TapeEntryKind] = Field(
+    kinds: list[str] = Field(
         default=["message", "tool_result"],
         description="Optional list of entry kinds to filter search results. Can include 'event', 'anchor', 'system', 'message', 'tool_call', 'tool_result', 'error'.",
     )

--- a/src/bub/tape.py
+++ b/src/bub/tape.py
@@ -9,21 +9,15 @@ from collections.abc import Callable, Coroutine, Iterable, Sequence
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime, time
 from datetime import date as date_type
-from typing import Any, Literal, NoReturn, Protocol, Self, get_args, overload
+from typing import Any, NoReturn, Protocol, Self, overload
 
 from typing_extensions import TypeIs
 
 from bub.runtime import BubError, ErrorKind
 
-type TapeEntryKind = Literal["event", "anchor", "system", "message", "tool_call", "tool_result", "error"]
-
 
 def utc_now() -> str:
     return datetime.now(UTC).isoformat()
-
-
-def is_tape_entry_kind(value: object) -> TypeIs[TapeEntryKind]:
-    return isinstance(value, str) and value in get_args(TapeEntryKind)
 
 
 @dataclass(frozen=True)
@@ -31,7 +25,7 @@ class TapeEntry:
     """A single append-only entry in a tape."""
 
     id: int
-    kind: TapeEntryKind
+    kind: str
     payload: dict[str, Any]
     meta: dict[str, Any] = field(default_factory=dict)
     date: str = field(default_factory=utc_now)
@@ -111,7 +105,7 @@ class TapeQuery[T: TapeStore | AsyncTapeStore]:
     _after_last: bool = False
     _between_anchors: tuple[str, str] | None = None
     _between_dates: tuple[str, str] | None = None
-    _kinds: tuple[TapeEntryKind, ...] = field(default_factory=tuple)
+    _kinds: tuple[str, ...] = field(default_factory=tuple)
     _limit: int | None = None
 
     def query(self, value: str) -> Self:
@@ -133,7 +127,7 @@ class TapeQuery[T: TapeStore | AsyncTapeStore]:
         end_value = end.isoformat() if isinstance(end, date_type) else end
         return replace(self, _between_dates=(start_value, end_value))
 
-    def kinds(self, *kinds: TapeEntryKind) -> Self:
+    def kinds(self, *kinds: str) -> Self:
         return replace(self, _kinds=kinds)
 
     def limit(self, value: int) -> Self:


### PR DESCRIPTION
as title

the first fix make tape works as before.... read entries, not ignore them

the second fix can expand `~/.bub` to `$HOME/.bub`