### PR TITLE
refactor: native any llm minimal and thinking printer

### DIFF
--- a/src/bub/builtin/agent.py
+++ b/src/bub/builtin/agent.py
@@ -13,22 +13,27 @@ from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from functools import cached_property
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal, cast
 
 from any_llm import AnyLLM
 from any_llm.types.completion import (
     ChatCompletion,
     ChatCompletionChunk,
     ChatCompletionMessage,
+    ChatCompletionMessageFunctionToolCall,
+    ChatCompletionMessageToolCall,
+    ChoiceDeltaToolCall,
+    Function,
     ParsedChatCompletion,
 )
 from loguru import logger
+from pydantic import TypeAdapter, ValidationError
 
 from bub.builtin.settings import ModelCandidate, load_settings
 from bub.builtin.store import ForkTapeStore
 from bub.builtin.tape import TapeService
 from bub.framework import BubFramework
-from bub.runtime import AsyncStreamEvents, BubError, StreamEvent, StreamState
+from bub.runtime import AsyncStreamEvents, BubError, ErrorKind, StreamEvent, StreamState
 from bub.skills import discover_skills, render_skills_prompt
 from bub.tape import InMemoryTapeStore, Tape
 from bub.tools import (
@@ -47,6 +52,7 @@ _CONTEXT_LENGTH_PATTERNS = re.compile(
     re.IGNORECASE,
 )
 MAX_AUTO_HANDOFF_RETRIES = 1
+TOOL_ARGUMENTS_ADAPTER = TypeAdapter(dict[str, Any])
 
 
 class Agent:
@@ -415,6 +421,7 @@ class Agent:
 
             model_tools_for_call = model_tools(tools)
             text_parts: list[str] = []
+            tool_calls = _ToolCallAccumulator()
             response: ChatCompletion | ParsedChatCompletion[Any] | None = None
             async with asyncio.timeout(self.settings.model_timeout_seconds):
                 completion = await self._completion_response(
@@ -424,7 +431,7 @@ class Agent:
                 )
                 if isinstance(completion, ChatCompletion):
                     response = completion
-                async for event in _completion_events(completion, state, text_parts):
+                async for event in _completion_events(completion, state, text_parts, tool_calls):
                     yield event
 
             assistant_message = response.choices[0].message if response is not None else None
@@ -433,12 +440,17 @@ class Agent:
                 if assistant_message and assistant_message.content is not None
                 else "".join(text_parts)
             )
-            resolved_tool_calls = _message_tool_calls(assistant_message) if assistant_message is not None else []
-            if resolved_tool_calls:
+            native_tool_calls = tool_calls.as_native()
+            if native_tool_calls:
+                tool_map = {tool_item.name: tool_item for tool_item in model_tools_for_call}
+                serialized_tool_calls = [tool_call.model_dump(exclude_none=True) for tool_call in native_tool_calls]
+                tool_invocations = [
+                    _tool_invocation_from_native(tool_call, tool_map) for tool_call in native_tool_calls
+                ]
+                yield StreamEvent("tool_call", {"tool_calls": serialized_tool_calls})
                 context = ToolContext(tape=tape.name, run_id=run_id, state=tape.context.state)
                 execution = await ToolExecutor().execute_async(
-                    resolved_tool_calls,
-                    tools=model_tools_for_call,
+                    tool_invocations,
                     context=context,
                 )
                 await self.tapes.record_chat(
@@ -447,16 +459,15 @@ class Agent:
                     system_prompt=system_prompt,
                     new_messages=[prompt_message],
                     response_text=None,
-                    tool_calls=execution.tool_calls,
+                    tool_calls=serialized_tool_calls,
                     tool_results=execution.tool_results,
                     response=response,
                     model=model or self.settings.model,
                     usage=state.usage,
                 )
-                yield StreamEvent("tool_call", {"tool_calls": execution.tool_calls})
                 yield StreamEvent("tool_result", {"tool_results": execution.tool_results})
                 yield StreamEvent(
-                    "final", {"ok": True, "tool_calls": execution.tool_calls, "tool_results": execution.tool_results}
+                    "final", {"ok": True, "tool_calls": serialized_tool_calls, "tool_results": execution.tool_results}
                 )
                 return
 
@@ -527,46 +538,124 @@ class Agent:
         return CONTINUE_PROMPT
 
 
+@dataclass
+class _StreamToolCall:
+    id: str | None = None
+    type: Literal["function"] | None = None
+    name: str | None = None
+    arguments: str = ""
+
+    def merge(self, delta: ChoiceDeltaToolCall) -> None:
+        if delta.id:
+            self.id = delta.id
+        if delta.type:
+            self.type = delta.type
+        if delta.function is None:
+            return
+        if delta.function.name:
+            if self.name is None or self.name == delta.function.name:
+                self.name = delta.function.name
+            else:
+                self.name += delta.function.name
+        if delta.function.arguments:
+            self.arguments += delta.function.arguments
+
+    def as_tool_call(self, index: int) -> ChatCompletionMessageFunctionToolCall:
+        return ChatCompletionMessageFunctionToolCall(
+            id=self.id or f"call_{index}",
+            type=self.type or "function",
+            function=Function(name=self.name or "", arguments=self.arguments or "{}"),
+        )
+
+
+class _ToolCallAccumulator:
+    def __init__(self) -> None:
+        self._message_calls: list[ChatCompletionMessageToolCall] = []
+        self._stream_calls: dict[int, _StreamToolCall] = {}
+
+    def add_message_calls(self, calls: Iterable[ChatCompletionMessageToolCall]) -> None:
+        self._message_calls.extend(calls)
+
+    def merge_delta_calls(self, deltas: Iterable[ChoiceDeltaToolCall]) -> None:
+        for delta in deltas:
+            self._stream_calls.setdefault(delta.index, _StreamToolCall()).merge(delta)
+
+    def as_native(self) -> list[ChatCompletionMessageToolCall]:
+        if self._message_calls:
+            return list(self._message_calls)
+        return [self._stream_calls[index].as_tool_call(index) for index in sorted(self._stream_calls)]
+
+
+def _tool_invocation_from_native(
+    tool_call: ChatCompletionMessageToolCall,
+    tool_map: dict[str, Tool],
+) -> tuple[Tool, dict[str, Any]]:
+    tool_name, arguments = _parse_native_function_call(tool_call)
+    tool_obj = tool_map.get(tool_name)
+    if tool_obj is None:
+        raise BubError(ErrorKind.TOOL, f"Unknown tool name: {tool_name}.")
+    return tool_obj, arguments
+
+
+def _parse_native_function_call(tool_call: ChatCompletionMessageToolCall) -> tuple[str, dict[str, Any]]:
+    if not isinstance(tool_call, ChatCompletionMessageFunctionToolCall):
+        raise BubError(ErrorKind.INVALID_INPUT, "Expected a function tool call with JSON object arguments.")
+    try:
+        arguments = TOOL_ARGUMENTS_ADAPTER.validate_json(tool_call.function.arguments or "{}")
+    except ValidationError as exc:
+        raise BubError(ErrorKind.INVALID_INPUT, "Expected a function tool call with JSON object arguments.") from exc
+    return tool_call.function.name, arguments
+
+
 async def _completion_events(
     completion: ChatCompletion | ParsedChatCompletion[Any] | AsyncIterator[ChatCompletionChunk],
     state: StreamState,
     text_parts: list[str],
+    tool_calls: _ToolCallAccumulator,
 ) -> AsyncGenerator[StreamEvent, None]:
     if isinstance(completion, ChatCompletion):
         if usage := TapeService._extract_usage(completion):
             state.usage = usage
         message = completion.choices[0].message
-        if message.reasoning:
-            yield StreamEvent("reasoning", {"delta": _reasoning_text(message.reasoning)})
-        if message.content:
-            text_parts.append(message.content)
-            yield StreamEvent("text", {"delta": message.content})
+        for event in _completion_message_events(message, text_parts, tool_calls):
+            yield event
         return
 
     async for chunk in completion:
-        if usage := TapeService._extract_usage(chunk):
-            state.usage = usage
-        for choice in chunk.choices:
-            delta = choice.delta
-            if delta.reasoning:
-                yield StreamEvent("reasoning", {"delta": _reasoning_text(delta.reasoning)})
-            if delta.content:
-                text_parts.append(delta.content)
-                yield StreamEvent("text", {"delta": delta.content})
+        async for event in _completion_chunk_events(chunk, state, text_parts, tool_calls):
+            yield event
 
 
-def _message_tool_calls(message: ChatCompletionMessage) -> list[dict[str, Any]]:
-    return [_model_dump(tool_call) for tool_call in message.tool_calls or []]
+def _completion_message_events(
+    message: ChatCompletionMessage,
+    text_parts: list[str],
+    tool_calls: _ToolCallAccumulator,
+) -> Iterable[StreamEvent]:
+    if message.reasoning:
+        yield StreamEvent("reasoning", {"delta": _reasoning_text(message.reasoning)})
+    if message.content:
+        text_parts.append(message.content)
+        yield StreamEvent("text", {"delta": message.content})
+    tool_calls.add_message_calls(cast("Iterable[ChatCompletionMessageToolCall]", message.tool_calls or []))
 
 
-def _model_dump(value: Any) -> dict[str, Any]:
-    if hasattr(value, "model_dump"):
-        payload = value.model_dump(exclude_none=True)
-        if isinstance(payload, dict):
-            return payload
-    if isinstance(value, dict):
-        return value
-    raise TypeError(f"expected model or dict, got {type(value).__name__}")
+async def _completion_chunk_events(
+    chunk: ChatCompletionChunk,
+    state: StreamState,
+    text_parts: list[str],
+    tool_calls: _ToolCallAccumulator,
+) -> AsyncGenerator[StreamEvent, None]:
+    if usage := TapeService._extract_usage(chunk):
+        state.usage = usage
+    for choice in chunk.choices:
+        delta = choice.delta
+        if delta.reasoning:
+            yield StreamEvent("reasoning", {"delta": _reasoning_text(delta.reasoning)})
+        if delta.content:
+            text_parts.append(delta.content)
+            yield StreamEvent("text", {"delta": delta.content})
+        if delta.tool_calls:
+            tool_calls.merge_delta_calls(delta.tool_calls)
 
 
 def _reasoning_text(reasoning: object) -> str:

--- a/src/bub/builtin/agent.py
+++ b/src/bub/builtin/agent.py
@@ -13,18 +13,16 @@ from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from functools import cached_property
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any
 
 from any_llm import AnyLLM
 from any_llm.types.completion import (
     ChatCompletion,
     ChatCompletionChunk,
     ChatCompletionMessage,
-    ChoiceDeltaToolCall,
+    ParsedChatCompletion,
 )
 from loguru import logger
-from openai.types.chat.chat_completion_message_custom_tool_call import ChatCompletionMessageCustomToolCall
-from openai.types.chat.chat_completion_message_function_tool_call import ChatCompletionMessageFunctionToolCall, Function
 
 from bub.builtin.settings import ModelCandidate, load_settings
 from bub.builtin.store import ForkTapeStore
@@ -417,8 +415,7 @@ class Agent:
 
             model_tools_for_call = model_tools(tools)
             text_parts: list[str] = []
-            tool_calls = _ToolCallAccumulator()
-            response: ChatCompletion | None = None
+            response: ChatCompletion | ParsedChatCompletion[Any] | None = None
             async with asyncio.timeout(self.settings.model_timeout_seconds):
                 completion = await self._completion_response(
                     model=model or self.settings.model,
@@ -427,11 +424,16 @@ class Agent:
                 )
                 if isinstance(completion, ChatCompletion):
                     response = completion
-                async for event in _completion_events(completion, state, text_parts, tool_calls):
+                async for event in _completion_events(completion, state, text_parts):
                     yield event
 
-            text = "".join(text_parts)
-            resolved_tool_calls = tool_calls.as_list()
+            assistant_message = response.choices[0].message if response is not None else None
+            text = (
+                assistant_message.content
+                if assistant_message and assistant_message.content is not None
+                else "".join(text_parts)
+            )
+            resolved_tool_calls = _message_tool_calls(assistant_message) if assistant_message is not None else []
             if resolved_tool_calls:
                 context = ToolContext(tape=tape.name, run_id=run_id, state=tape.context.state)
                 execution = await ToolExecutor().execute_async(
@@ -480,7 +482,7 @@ class Agent:
 
     async def _completion_response(
         self, *, model: str, messages: list[dict[str, Any]], tools: list[Tool]
-    ) -> ChatCompletion | AsyncIterator[ChatCompletionChunk]:
+    ) -> ChatCompletion | ParsedChatCompletion[Any] | AsyncIterator[ChatCompletionChunk]:
         from bub.builtin.tools import completion_tools
 
         tool_payloads = completion_tools(tools) or None
@@ -525,70 +527,20 @@ class Agent:
         return CONTINUE_PROMPT
 
 
-@dataclass
-class _StreamToolCall:
-    id: str | None = None
-    type: Literal["function"] | None = None
-    name: str | None = None
-    arguments: str = ""
-
-    def merge(self, delta: ChoiceDeltaToolCall) -> None:
-        if delta.id:
-            self.id = delta.id
-        if delta.type:
-            self.type = delta.type
-        if delta.function is None:
-            return
-        if delta.function.name:
-            if self.name is None or self.name == delta.function.name:
-                self.name = delta.function.name
-            else:
-                self.name += delta.function.name
-        if delta.function.arguments:
-            self.arguments += delta.function.arguments
-
-    def as_tool_call(self, index: int) -> ChatCompletionMessageFunctionToolCall:
-        return ChatCompletionMessageFunctionToolCall(
-            id=self.id or f"call_{index}",
-            type=self.type or "function",
-            function=Function(name=self.name or "", arguments=self.arguments or "{}"),
-        )
-
-
-class _ToolCallAccumulator:
-    def __init__(self) -> None:
-        self._calls: list[ChatCompletionMessageFunctionToolCall | ChatCompletionMessageCustomToolCall] = []
-        self._stream_calls: dict[int, _StreamToolCall] = {}
-
-    def add_message_call(
-        self, call: ChatCompletionMessageFunctionToolCall | ChatCompletionMessageCustomToolCall
-    ) -> None:
-        self._calls.append(call)
-
-    def merge_delta_calls(self, deltas: Iterable[ChoiceDeltaToolCall]) -> None:
-        for delta in deltas:
-            self._stream_calls.setdefault(delta.index, _StreamToolCall()).merge(delta)
-
-    def as_list(self) -> list[dict[str, Any]]:
-        calls = self._calls or [self._stream_calls[index].as_tool_call(index) for index in sorted(self._stream_calls)]
-        return [call.model_dump(exclude_none=True) for call in calls]
-
-
 async def _completion_events(
-    completion: ChatCompletion | AsyncIterator[ChatCompletionChunk],
+    completion: ChatCompletion | ParsedChatCompletion[Any] | AsyncIterator[ChatCompletionChunk],
     state: StreamState,
     text_parts: list[str],
-    tool_calls: _ToolCallAccumulator,
 ) -> AsyncGenerator[StreamEvent, None]:
     if isinstance(completion, ChatCompletion):
         if usage := TapeService._extract_usage(completion):
             state.usage = usage
         message = completion.choices[0].message
+        if message.reasoning:
+            yield StreamEvent("reasoning", {"delta": _reasoning_text(message.reasoning)})
         if message.content:
             text_parts.append(message.content)
             yield StreamEvent("text", {"delta": message.content})
-        for tool_call in message.tool_calls or []:
-            tool_calls.add_message_call(tool_call)
         return
 
     async for chunk in completion:
@@ -596,11 +548,30 @@ async def _completion_events(
             state.usage = usage
         for choice in chunk.choices:
             delta = choice.delta
+            if delta.reasoning:
+                yield StreamEvent("reasoning", {"delta": _reasoning_text(delta.reasoning)})
             if delta.content:
                 text_parts.append(delta.content)
                 yield StreamEvent("text", {"delta": delta.content})
-            if delta.tool_calls:
-                tool_calls.merge_delta_calls(delta.tool_calls)
+
+
+def _message_tool_calls(message: ChatCompletionMessage) -> list[dict[str, Any]]:
+    return [_model_dump(tool_call) for tool_call in message.tool_calls or []]
+
+
+def _model_dump(value: Any) -> dict[str, Any]:
+    if hasattr(value, "model_dump"):
+        payload = value.model_dump(exclude_none=True)
+        if isinstance(payload, dict):
+            return payload
+    if isinstance(value, dict):
+        return value
+    raise TypeError(f"expected model or dict, got {type(value).__name__}")
+
+
+def _reasoning_text(reasoning: object) -> str:
+    content = getattr(reasoning, "content", reasoning)
+    return "" if content is None else str(content)
 
 
 @dataclass(frozen=True)

--- a/src/bub/channels/cli/__init__.py
+++ b/src/bub/channels/cli/__init__.py
@@ -46,6 +46,8 @@ class _StreamPrinter:
 
         if event.kind == "text":
             return self._print_content(str(event.data.get("delta", "")))
+        elif event.kind == "tool_call":
+            self._print_stream_boundary()
         elif event.kind == "final":
             self._print_end()
         return True
@@ -77,7 +79,14 @@ class _StreamPrinter:
         if self._reasoning_chars:
             self._ensure_head()
         self._flush_reasoning()
-        self._console.print("\n")  # ensure the next log or prompt starts on its own line
+        if self.head_printed:
+            self._console.print("")
+
+    def _print_stream_boundary(self) -> None:
+        self._close_reasoning_stream()
+        self._flush_reasoning()
+        if self.head_printed:
+            self._console.print("")
 
     def _ensure_head(self) -> None:
         if self.head_printed:

--- a/src/bub/channels/cli/__init__.py
+++ b/src/bub/channels/cli/__init__.py
@@ -1,6 +1,6 @@
 import asyncio
 import contextlib
-from collections.abc import AsyncGenerator, AsyncIterable
+from collections.abc import AsyncGenerator, AsyncIterable, Callable
 from datetime import datetime
 from hashlib import md5
 from pathlib import Path
@@ -13,6 +13,9 @@ from prompt_toolkit.history import FileHistory
 from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.patch_stdout import patch_stdout
 from rich import get_console
+from rich.status import Status
+from rich.text import Text
+from rich.tree import Tree
 
 import bub
 from bub.builtin.agent import Agent
@@ -24,6 +27,91 @@ from bub.envelope import field_of
 from bub.runtime import StreamEvent
 from bub.tools import REGISTRY
 from bub.types import MessageHandler
+
+
+class _StreamPrinter:
+    def __init__(self, *, console, print_head: Callable[[], None], expand_reasoning: bool) -> None:
+        self._console = console
+        self._print_head = print_head
+        self._expand_reasoning = expand_reasoning
+        self._reasoning_chars = 0
+        self._reasoning_streaming = False
+        self._reasoning_status: Status | None = None
+        self.head_printed = False
+
+    def render(self, event: StreamEvent) -> bool:
+        if event.kind == "reasoning":
+            self._record_reasoning(str(event.data.get("delta", "")))
+            return True
+
+        if event.kind == "text":
+            return self._print_content(str(event.data.get("delta", "")))
+        elif event.kind == "final":
+            self._print_end()
+        return True
+
+    def _record_reasoning(self, reasoning: str) -> None:
+        if not self._expand_reasoning:
+            if self._reasoning_chars == 0:
+                self._ensure_head()
+                self._start_reasoning_status()
+            self._reasoning_chars += len(reasoning)
+            return
+
+        self._ensure_head()
+        if not self._reasoning_streaming:
+            self._console.print(Text("[-] Thinking", style="bright_black"))
+            self._reasoning_streaming = True
+        self._console.print(Text(reasoning, style="bright_black"), end="", highlight=False)
+
+    def _print_content(self, content: str) -> bool:
+        if not (content.strip() or self.head_printed or self._reasoning_chars or self._reasoning_streaming):
+            return False
+        self._ensure_head()
+        self._close_reasoning_stream()
+        self._flush_reasoning()
+        self._console.print(content, end="", highlight=False)
+        return True
+
+    def _print_end(self) -> None:
+        if self._reasoning_chars:
+            self._ensure_head()
+        self._flush_reasoning()
+        self._console.print("\n")  # ensure the next log or prompt starts on its own line
+
+    def _ensure_head(self) -> None:
+        if self.head_printed:
+            return
+        self._print_head()
+        self.head_printed = True
+
+    def _close_reasoning_stream(self) -> None:
+        if not self._reasoning_streaming:
+            return
+        self._console.print("")
+        self._reasoning_streaming = False
+
+    def _flush_reasoning(self) -> None:
+        if self._reasoning_chars <= 0:
+            return
+        self._stop_reasoning_status()
+        label = Text(f"[+] Thinking ({self._reasoning_chars} chars hidden)", style="bright_black")
+        self._console.print(Tree(label, guide_style="bright_black", expanded=False))
+        self._reasoning_chars = 0
+
+    def _start_reasoning_status(self) -> None:
+        if self._reasoning_status is not None:
+            return
+        self._reasoning_status = self._console.status(
+            Text("Thinking", style="bright_black"), spinner_style="bright_black"
+        )
+        self._reasoning_status.start()
+
+    def _stop_reasoning_status(self) -> None:
+        if self._reasoning_status is None:
+            return
+        self._reasoning_status.stop()
+        self._reasoning_status = None
 
 
 class CliChannel(Interface):
@@ -41,6 +129,7 @@ class CliChannel(Interface):
             "session_id": "cli_session",
         }
         self._mode = "agent"  # or "shell"
+        self._expand_thinking = False
         self._main_task: asyncio.Task | None = None
         self._renderer = CliRenderer(get_console())
         self._last_tape_info: TapeInfo | None = None
@@ -100,6 +189,9 @@ class CliChannel(Interface):
                 continue
             if raw in {",quit", ",exit"}:
                 break
+            if raw == ",thinking":
+                self._toggle_thinking()
+                continue
 
             request = self._normalize_input(raw)
 
@@ -140,21 +232,15 @@ class CliChannel(Interface):
     async def stream_events(
         self, message: ChannelMessage, stream: AsyncIterable[StreamEvent]
     ) -> AsyncIterable[StreamEvent]:
-        head_printed = False
         console = get_console()
+        printer = _StreamPrinter(
+            console=console,
+            print_head=lambda: self._renderer.print_head(message.kind),
+            expand_reasoning=getattr(self, "_expand_thinking", False),
+        )
         async for event in stream:
-            if event.kind == "text":
-                content = str(event.data.get("delta", ""))
-                if not content.strip() and not head_printed:
-                    continue  # skip leading whitespace-only events
-                if not head_printed:
-                    self._renderer.print_head(message.kind)
-                    head_printed = True
-
-                console.print(content, end="", highlight=False)
-            elif event.kind == "final":
-                console.print("\n")  # ensure we end with a newline after the final event
-            yield event
+            if printer.render(event):
+                yield event
 
     def _build_prompt(self, workspace: Path) -> PromptSession[str]:
         kb = KeyBindings()
@@ -171,7 +257,7 @@ class CliChannel(Interface):
         history_file = self._history_file(bub.home, workspace)
         history_file.parent.mkdir(parents=True, exist_ok=True)
         history = FileHistory(str(history_file))
-        tool_names = sorted((f",{name}" for name in REGISTRY), key=_tool_sort_key)
+        tool_names = sorted([*(f",{name}" for name in REGISTRY), ",thinking"], key=_tool_sort_key)
         completer = WordCompleter(tool_names, ignore_case=True, sentence=True)
         return PromptSession(
             completer=completer,
@@ -186,12 +272,18 @@ class CliChannel(Interface):
         now = datetime.now().strftime("%H:%M")
         left = f"{now}  mode:{self._mode}"
         right = (
+            f"thinking:{'expand' if self._expand_thinking else 'collapse'}  "
             f"model:{self._agent.settings.model}  "
             f"entries:{field_of(info, 'entries', '-')} "
             f"anchors:{field_of(info, 'anchors', '-')} "
             f"last:{field_of(info, 'last_anchor', None) or '-'}"
         )
         return FormattedText([("", f"{left}  {right}")])
+
+    def _toggle_thinking(self) -> None:
+        self._expand_thinking = not self._expand_thinking
+        state = "expanded" if self._expand_thinking else "collapsed"
+        self._renderer.info(f"Thinking output is now {state}.")
 
     @staticmethod
     def _history_file(home: Path, workspace: Path) -> Path:

--- a/src/bub/channels/cli/__init__.py
+++ b/src/bub/channels/cli/__init__.py
@@ -30,10 +30,10 @@ from bub.types import MessageHandler
 
 
 class _StreamPrinter:
-    def __init__(self, *, console, print_head: Callable[[], None], expand_reasoning: bool) -> None:
+    def __init__(self, *, console, print_head: Callable[[], None], expand_thinking: bool) -> None:
         self._console = console
         self._print_head = print_head
-        self._expand_reasoning = expand_reasoning
+        self._expand_thinking = expand_thinking
         self._reasoning_chars = 0
         self._reasoning_streaming = False
         self._reasoning_status: Status | None = None
@@ -51,7 +51,7 @@ class _StreamPrinter:
         return True
 
     def _record_reasoning(self, reasoning: str) -> None:
-        if not self._expand_reasoning:
+        if not self._expand_thinking:
             if self._reasoning_chars == 0:
                 self._ensure_head()
                 self._start_reasoning_status()
@@ -60,9 +60,9 @@ class _StreamPrinter:
 
         self._ensure_head()
         if not self._reasoning_streaming:
-            self._console.print(Text("[-] Thinking", style="bright_black"))
+            self._console.print(Text("[-] Thinking", style="dim"))
             self._reasoning_streaming = True
-        self._console.print(Text(reasoning, style="bright_black"), end="", highlight=False)
+        self._console.print(Text(reasoning, style="dim"), end="", highlight=False)
 
     def _print_content(self, content: str) -> bool:
         if not (content.strip() or self.head_printed or self._reasoning_chars or self._reasoning_streaming):
@@ -95,16 +95,14 @@ class _StreamPrinter:
         if self._reasoning_chars <= 0:
             return
         self._stop_reasoning_status()
-        label = Text(f"[+] Thinking ({self._reasoning_chars} chars hidden)", style="bright_black")
-        self._console.print(Tree(label, guide_style="bright_black", expanded=False))
+        label = Text(f"[+] Thinking ({self._reasoning_chars} chars hidden)", style="dim")
+        self._console.print(Tree(label, guide_style="dim", expanded=False))
         self._reasoning_chars = 0
 
     def _start_reasoning_status(self) -> None:
         if self._reasoning_status is not None:
             return
-        self._reasoning_status = self._console.status(
-            Text("Thinking", style="bright_black"), spinner_style="bright_black"
-        )
+        self._reasoning_status = self._console.status(Text("Thinking", style="dim"), spinner_style="dim")
         self._reasoning_status.start()
 
     def _stop_reasoning_status(self) -> None:
@@ -236,7 +234,7 @@ class CliChannel(Interface):
         printer = _StreamPrinter(
             console=console,
             print_head=lambda: self._renderer.print_head(message.kind),
-            expand_reasoning=getattr(self, "_expand_thinking", False),
+            expand_thinking=self._expand_thinking,
         )
         async for event in stream:
             if printer.render(event):

--- a/src/bub/channels/cli/renderer.py
+++ b/src/bub/channels/cli/renderer.py
@@ -58,4 +58,4 @@ class CliRenderer:
     def log(self, message: object) -> None:
         text = str(message).rstrip()
         if text:
-            self.console.print(text)
+            self.console.print(text, new_line_start=True)

--- a/src/bub/runtime.py
+++ b/src/bub/runtime.py
@@ -49,7 +49,7 @@ class StreamState:
 
 @dataclass(frozen=True)
 class StreamEvent:
-    kind: Literal["text", "tool_call", "tool_result", "usage", "error", "final"]
+    kind: Literal["text", "reasoning", "tool_call", "tool_result", "usage", "error", "final"]
     data: dict[str, Any]
 
 

--- a/src/bub/tools.py
+++ b/src/bub/tools.py
@@ -101,32 +101,26 @@ class Tool:
 
 @dataclass(frozen=True)
 class ToolExecution:
-    tool_calls: list[dict[str, Any]] = field(default_factory=list)
     tool_results: list[Any] = field(default_factory=list)
     error: BubError | None = None
 
 
 class ToolExecutor:
-    """Execute model tool calls with predictable validation and serialization."""
+    """Execute already-resolved Bub tool invocations."""
 
     async def execute_async(
         self,
-        response: list[dict[str, Any]] | dict[str, Any] | str,
-        tools: Sequence[Tool] | None = None,
+        invocations: Sequence[tuple[Tool, dict[str, Any]]],
         *,
         context: ToolContext | None = None,
     ) -> ToolExecution:
-        tool_calls = self._normalize_response(response)
-        tool_map = self._build_tool_map(tools)
-        if not tool_map:
-            if tool_calls:
-                raise BubError(ErrorKind.TOOL, "No runnable tools are available.")
-            return ToolExecution(tool_calls=[], tool_results=[])
+        if not invocations:
+            return ToolExecution(tool_results=[])
 
         results: list[Any] = []
         error: BubError | None = None
         gathered = await asyncio.gather(
-            *(self._handle_tool_response_async(tool_response, tool_map, context) for tool_response in tool_calls),
+            *(self._handle_tool_response_async(tool_obj, tool_args, context) for tool_obj, tool_args in invocations),
             return_exceptions=True,
         )
         for result in gathered:
@@ -138,24 +132,7 @@ class ToolExecutor:
             else:
                 results.append(result)
 
-        return ToolExecution(tool_calls=tool_calls, tool_results=results, error=error)
-
-    def _resolve_tool_call(
-        self,
-        tool_response: Any,
-        tool_map: dict[str, Tool],
-    ) -> tuple[str, Tool, dict[str, Any]]:
-        if not isinstance(tool_response, dict):
-            raise BubError(ErrorKind.INVALID_INPUT, "Each tool call must be an object.")
-        tool_name = tool_response.get("function", {}).get("name")
-        if not tool_name:
-            raise BubError(ErrorKind.INVALID_INPUT, "Tool call is missing name.")
-        tool_obj = tool_map.get(tool_name)
-        if tool_obj is None:
-            raise BubError(ErrorKind.TOOL, f"Unknown tool name: {tool_name}.")
-        tool_args = tool_response.get("function", {}).get("arguments", {})
-        tool_args = self._normalize_tool_args(str(tool_name), tool_args)
-        return str(tool_name), tool_obj, tool_args
+        return ToolExecution(tool_results=results, error=error)
 
     def _invoke_tool(
         self,
@@ -173,11 +150,11 @@ class ToolExecutor:
 
     async def _handle_tool_response_async(
         self,
-        tool_response: Any,
-        tool_map: dict[str, Tool],
+        tool_obj: Tool,
+        tool_args: dict[str, Any],
         context: ToolContext | None,
     ) -> Any:
-        tool_name, tool_obj, tool_args = self._resolve_tool_call(tool_response, tool_map)
+        tool_name = tool_obj.name
         try:
             result = self._invoke_tool(
                 tool_name=tool_name,
@@ -203,40 +180,6 @@ class ToolExecutor:
             ) from exc
         else:
             return result
-
-    def _normalize_response(
-        self,
-        response: list[dict[str, Any]] | dict[str, Any] | str,
-    ) -> list[dict[str, Any]]:
-        if isinstance(response, str):
-            try:
-                response = json.loads(response)
-            except json.JSONDecodeError as exc:
-                raise BubError(
-                    ErrorKind.INVALID_INPUT,
-                    "Tool response is not a valid JSON string.",
-                    details={"error": str(exc)},
-                ) from exc
-        if isinstance(response, dict):
-            response = [response]
-        if not isinstance(response, list):
-            raise BubError(ErrorKind.INVALID_INPUT, "Tool response must be a list of objects.")
-        return response
-
-    def _build_tool_map(self, tools: Sequence[Tool] | None) -> dict[str, Tool]:
-        if tools is None:
-            raise BubError(ErrorKind.INVALID_INPUT, "No tools provided.")
-        return {tool_obj.name: tool_obj for tool_obj in tools}
-
-    def _normalize_tool_args(self, tool_name: str, tool_args: Any) -> dict[str, Any]:
-        if isinstance(tool_args, str):
-            try:
-                tool_args = json.loads(tool_args)
-            except json.JSONDecodeError as exc:
-                raise BubError(ErrorKind.INVALID_INPUT, f"Tool '{tool_name}' arguments are not valid JSON.") from exc
-        if isinstance(tool_args, dict):
-            return dict(tool_args)
-        raise BubError(ErrorKind.INVALID_INPUT, f"Tool '{tool_name}' arguments must be an object.")
 
 
 # Central registry for tools. Tools defined with the @tool decorator are automatically added here.

--- a/tests/test_builtin_tools.py
+++ b/tests/test_builtin_tools.py
@@ -201,15 +201,8 @@ async def test_foreground_bash_terminates_shell_when_cancelled(tmp_path, monkeyp
 async def test_bash_non_zero_exit_is_returned_as_tool_error(tmp_path) -> None:
     command = _python_shell("import sys; print('boom'); sys.exit(7)")
     executor = ToolExecutor()
-    tool_call = {
-        "type": "function",
-        "function": {
-            "name": bash.name,
-            "arguments": {"cmd": command},
-        },
-    }
 
-    result = await executor.execute_async([tool_call], tools=[bash], context=_tool_context(tmp_path))
+    result = await executor.execute_async([(bash, {"cmd": command})], context=_tool_context(tmp_path))
 
     assert result.error is not None
     assert result.error.kind is ErrorKind.TOOL

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -664,6 +664,7 @@ async def test_cli_channel_stream_events_prints_stream_and_yields_events(monkeyp
     heads: list[str] = []
     printed: list[tuple[str, str | None, bool | None]] = []
     channel._renderer = SimpleNamespace(print_head=heads.append)
+    channel._expand_thinking = False
     monkeypatch.setattr(
         "bub.channels.cli.get_console",
         lambda: SimpleNamespace(

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -683,7 +683,7 @@ async def test_cli_channel_stream_events_prints_stream_and_yields_events(monkeyp
     yielded = [event async for event in channel.stream_events(message, source())]
 
     assert heads == ["command"]
-    assert printed == [("hel", "", False), ("lo", "", False), ("\n", None, None)]
+    assert printed == [("hel", "", False), ("lo", "", False), ("", None, None)]
     assert [event.kind for event in yielded] == ["text", "text", "final"]
 
 


### PR DESCRIPTION
- The builtin agent now reads any-llm reasoning output directly and emits StreamEvent("reasoning", ...).
- Removed custom OpenAI-style streamed tool-call aggregation from the agent.
- Added reasoning to runtime stream event kinds.
- Added a local CLI ,thinking toggle:
    - collapse by default: shows thinking status and hidden character count.
    - expand: streams thinking content visibly.
- Preserved existing CLI text/final streaming behavior.