### PR TITLE
fix: remove deprecated run method from Agent and its hook implementation

### DIFF
--- a/src/bub/builtin/agent.py
+++ b/src/bub/builtin/agent.py
@@ -93,30 +93,6 @@ class Agent:
 
         return AsyncStreamEvents(generator(), state=events._state)
 
-    async def run(
-        self,
-        *,
-        session_id: str,
-        prompt: str | list[dict],
-        state: State,
-        model: str | None = None,
-        allowed_skills: Collection[str] | None = None,
-        allowed_tools: Collection[str] | None = None,
-    ) -> str:
-        output: list[str] = []
-        stream = await self.run_stream(
-            session_id=session_id,
-            prompt=prompt,
-            state=state,
-            model=model,
-            allowed_skills=allowed_skills,
-            allowed_tools=allowed_tools,
-        )
-        async for event in stream:
-            if event.kind == "text":
-                output.append(str(event.data.get("delta", "")))
-        return "".join(output)
-
     async def run_stream(
         self,
         *,

--- a/src/bub/builtin/hook_impl.py
+++ b/src/bub/builtin/hook_impl.py
@@ -156,10 +156,6 @@ class BuiltinImpl:
         return text
 
     @hookimpl
-    async def run_model(self, prompt: str | list[dict], session_id: str, state: State) -> str:
-        return await self._get_agent().run(session_id=session_id, prompt=prompt, state=state)
-
-    @hookimpl
     async def run_model_stream(self, prompt: str | list[dict], session_id: str, state: State) -> AsyncStreamEvents:
         return await self._get_agent().run_stream(session_id=session_id, prompt=prompt, state=state)
 

--- a/tests/test_builtin_hook_impl.py
+++ b/tests/test_builtin_hook_impl.py
@@ -152,18 +152,6 @@ async def test_build_prompt_uses_system_timezone_for_context_date(
 
 
 @pytest.mark.asyncio
-async def test_run_model_delegates_to_agent(tmp_path: Path) -> None:
-    _, impl, agent = _build_impl(tmp_path)
-    state = {"context": "ctx"}
-
-    result = await impl.run_model(prompt="prompt", session_id="session", state=state)
-
-    assert result == "agent-output"
-    assert agent.run_calls == [("session", "prompt", state)]
-    assert agent.run_stream_calls == []
-
-
-@pytest.mark.asyncio
 async def test_run_model_stream_delegates_to_agent(tmp_path: Path) -> None:
     _, impl, agent = _build_impl(tmp_path)
     state = {"context": "ctx"}


### PR DESCRIPTION
Signed-off-by: Frost Ming <me@frostming.com>