### PR TITLE
docs: remove obsolete pinning notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Bub
 
-> We are actively working on version 0.4.0. Until then, please pin [0.3.9 on PyPI](https://pypi.org/project/bub/0.3.9/) or [e5d8ceb](https://github.com/bubbuild/bub/tree/e5d8ceb3b30105e0d50e872be7d6ae6fb4066236) .
-
 <div align="center">
 
 <picture>


### PR DESCRIPTION
## Summary

- remove the obsolete README notice that asks users to pin Bub 0.3.9 or commit `e5d8ceb`
- leave the current installation instructions unchanged

## Why

The notice no longer reflects the project's current installation guidance and makes the README point users at an old release or commit.

## Validation

- commit hooks passed
- `git diff --check` passed
- website build was attempted; local pnpm lifecycle policy blocked dependency build scripts before the docs build could start