### PR TITLE
feat(cli): add flicker-free streaming Markdown rendering

### DIFF
--- a/src/bub/channels/cli/__init__.py
+++ b/src/bub/channels/cli/__init__.py
@@ -15,7 +15,6 @@ from prompt_toolkit.formatted_text import FormattedText
 from prompt_toolkit.history import FileHistory
 from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.patch_stdout import patch_stdout
-from prompt_toolkit.utils import get_cwidth
 from rich import get_console
 from rich.spinner import SPINNERS
 from rich.text import Text
@@ -27,6 +26,7 @@ from bub.builtin.tape import TapeInfo
 from bub.channels.admission import AdmitDecision, TurnSnapshot
 from bub.channels.base import Interface
 from bub.channels.cli.renderer import CliRenderer
+from bub.channels.cli.writers import MarkdownWriter, PlainTextWriter, StreamWriter
 from bub.channels.contracts import MessageHandler
 from bub.channels.message import ChannelMessage
 from bub.envelope import Envelope, field_of
@@ -38,16 +38,30 @@ _PROMPT_REFRESH_INTERVAL: float = SPINNERS["dots"]["interval"] / 1000.0  # type:
 
 
 class _StreamPrinter:
-    def __init__(self, *, console, print_head: Callable[[], None], expand_thinking: bool) -> None:
+    def __init__(
+        self,
+        *,
+        console,
+        print_head: Callable[[], None],
+        expand_thinking: bool,
+        writer: StreamWriter | None = None,
+    ) -> None:
         self._console = console
         self._print_head = print_head
         self._expand_thinking = expand_thinking
         self._reasoning_chars = 0
         self._reasoning_streaming = False
-        self._current_text_line = ""
-        self._rendered_text_line: str | None = None
-        self._live_text_rows = 0
+        self._writer: StreamWriter = writer or self._default_writer()
+        self._live_rows = 0
         self.head_printed = False
+
+    @staticmethod
+    def _default_writer() -> StreamWriter:
+        import os
+
+        if os.environ.get("BUB_CLI_RENDER") == "plain":
+            return PlainTextWriter()
+        return MarkdownWriter()
 
     async def render(self, event: StreamEvent) -> bool:
         if event.kind == "reasoning":
@@ -88,15 +102,15 @@ class _StreamPrinter:
         if self._reasoning_chars:
             await self._ensure_head()
         await self._flush_reasoning()
-        if self._current_text_line:
+        if self._writer.has_content():
             await self._commit_text_line()
-        elif self.head_printed and not self._live_text_rows:
+        elif self.head_printed and not self._live_rows:
             await self._print("")
 
     async def _print_stream_boundary(self) -> None:
         await self._close_reasoning_stream()
         await self._flush_reasoning()
-        if self._current_text_line or self._live_text_rows:
+        if self._writer.has_content() or self._live_rows:
             await self._commit_text_line()
         if self.head_printed:
             await self._print("")
@@ -121,48 +135,58 @@ class _StreamPrinter:
         self._reasoning_chars = 0
 
     async def _write_text(self, text: str) -> None:
-        parts = text.split("\n")
-        for index, part in enumerate(parts):
-            self._current_text_line += part
-            if index < len(parts) - 1:
-                await self._commit_text_line()
+        self._writer.append(text)
+        while self._writer.can_commit():
+            await self._commit_writer()
+        await self._render_live()
 
-        if self._current_text_line:
-            await self._render_live_text_line()
-
-    async def _commit_text_line(self) -> None:
-        if self._live_text_rows and self._rendered_text_line == self._current_text_line:
-            self._current_text_line = ""
-            self._rendered_text_line = None
-            self._live_text_rows = 0
-            return
-        self._live_text_rows = await self._render_text_line(self._current_text_line)
-        self._current_text_line = ""
-        self._rendered_text_line = None
-        self._live_text_rows = 0
-
-    async def commit_live_text(self) -> None:
-        if self._current_text_line or self._live_text_rows:
-            await self._commit_text_line()
-
-    async def _render_live_text_line(self) -> None:
-        self._live_text_rows = await self._render_text_line(self._current_text_line)
-        self._rendered_text_line = self._current_text_line
-
-    async def _render_text_line(self, text: str) -> int:
-        previous_rows = self._live_text_rows
-        rows = self._display_rows(text)
+    async def _commit_writer(self) -> None:
+        committed = self._writer.render_committed()
+        console_width = int(getattr(self._console, "width", 80) or 80)
 
         def render() -> None:
-            self._rewind_live_text(previous_rows)
-            self._console.print(f"{text}\n", end="", highlight=False)
+            self._rewind_live_text(self._live_rows)
+            self._console.print(committed, end="")
+            self._console.print("", highlight=False)
 
         await run_in_terminal(render, render_cli_done=False)
-        return rows
+        self._writer.commit()
+        self._live_rows = 0
 
-    def _display_rows(self, text: str) -> int:
-        columns = max(1, int(getattr(self._console, "width", 80) or 80))
-        return max(1, (get_cwidth(text) + columns - 1) // columns)
+    async def _render_live(self) -> None:
+        partial = self._writer.render_partial()
+        console_width = int(getattr(self._console, "width", 80) or 80)
+        new_rows = self._writer.row_count(partial, console_width)
+
+        def render() -> None:
+            self._rewind_live_text(self._live_rows)
+            if new_rows > 0:
+                self._console.print(partial, end="", highlight=False)
+
+        await run_in_terminal(render, render_cli_done=False)
+        self._live_rows = new_rows
+
+    async def _commit_text_line(self) -> None:
+        if self._writer.can_commit():
+            await self._commit_writer()
+        if self._writer.has_content():
+            flushed = self._writer.flush()
+            if flushed is not None:
+                def render() -> None:
+                    self._rewind_live_text(self._live_rows)
+                    self._console.print(flushed, end="")
+                    self._console.print("", highlight=False)
+                await run_in_terminal(render, render_cli_done=False)
+                self._live_rows = 0
+        elif self._live_rows:
+            def render() -> None:
+                self._rewind_live_text(self._live_rows)
+            await run_in_terminal(render, render_cli_done=False)
+            self._live_rows = 0
+
+    async def commit_live_text(self) -> None:
+        if self._writer.has_content() or self._live_rows:
+            await self._commit_text_line()
 
     def _rewind_live_text(self, rows: int) -> None:
         if rows <= 0:

--- a/src/bub/channels/cli/__init__.py
+++ b/src/bub/channels/cli/__init__.py
@@ -11,12 +11,13 @@ from loguru import logger
 from prompt_toolkit import PromptSession
 from prompt_toolkit.application import run_in_terminal
 from prompt_toolkit.completion import WordCompleter
-from prompt_toolkit.formatted_text import FormattedText
+from prompt_toolkit.formatted_text import ANSI, AnyFormattedText, FormattedText, merge_formatted_text
 from prompt_toolkit.history import FileHistory
 from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.patch_stdout import patch_stdout
 from rich import get_console
-from rich.spinner import SPINNERS
+from rich.console import Group, RenderableType
+from rich.spinner import SPINNERS, Spinner
 from rich.text import Text
 from rich.tree import Tree
 
@@ -25,7 +26,14 @@ from bub.builtin.agent import Agent
 from bub.builtin.tape import TapeInfo
 from bub.channels.admission import AdmitDecision, TurnSnapshot
 from bub.channels.base import Interface
+from bub.channels.cli.ansi_bridge import render_to_ansi
 from bub.channels.cli.renderer import CliRenderer
+from bub.channels.cli.terminal_output import (
+    create_synchronized_output,
+    direct_terminal_stdio,
+    restore_synchronized_prompt,
+    synchronized_prompt_output,
+)
 from bub.channels.cli.writers import MarkdownWriter, PlainTextWriter, StreamWriter
 from bub.channels.contracts import MessageHandler
 from bub.channels.message import ChannelMessage
@@ -45,6 +53,7 @@ class _StreamPrinter:
         print_head: Callable[[], None],
         expand_thinking: bool,
         writer: StreamWriter | None = None,
+        invalidate: Callable[[], None] | None = None,
     ) -> None:
         self._console = console
         self._print_head = print_head
@@ -52,7 +61,8 @@ class _StreamPrinter:
         self._reasoning_chars = 0
         self._reasoning_streaming = False
         self._writer: StreamWriter = writer or self._default_writer()
-        self._live_rows = 0
+        self._invalidate = invalidate or (lambda: None)
+        self._spinner = Spinner("dots", text="Generating...")
         self.head_printed = False
 
     @staticmethod
@@ -104,13 +114,13 @@ class _StreamPrinter:
         await self._flush_reasoning()
         if self._writer.has_content():
             await self._commit_text_line()
-        elif self.head_printed and not self._live_rows:
+        elif self.head_printed:
             await self._print("")
 
     async def _print_stream_boundary(self) -> None:
         await self._close_reasoning_stream()
         await self._flush_reasoning()
-        if self._writer.has_content() or self._live_rows:
+        if self._writer.has_content():
             await self._commit_text_line()
         if self.head_printed:
             await self._print("")
@@ -118,7 +128,7 @@ class _StreamPrinter:
     async def _ensure_head(self) -> None:
         if self.head_printed:
             return
-        await run_in_terminal(self._print_head, render_cli_done=False)
+        await self._run_in_terminal(self._print_head)
         self.head_printed = True
 
     async def _close_reasoning_stream(self) -> None:
@@ -142,29 +152,20 @@ class _StreamPrinter:
 
     async def _commit_writer(self) -> None:
         committed = self._writer.render_committed()
-        console_width = int(getattr(self._console, "width", 80) or 80)
 
         def render() -> None:
-            self._rewind_live_text(self._live_rows)
-            self._console.print(committed, end="")
-            self._console.print("", highlight=False)
+            self._console.print(committed)
 
-        await run_in_terminal(render, render_cli_done=False)
+        await self._run_in_terminal(render)
         self._writer.commit()
-        self._live_rows = 0
 
     async def _render_live(self) -> None:
-        partial = self._writer.render_partial()
-        console_width = int(getattr(self._console, "width", 80) or 80)
-        new_rows = self._writer.row_count(partial, console_width)
+        self._invalidate()
 
-        def render() -> None:
-            self._rewind_live_text(self._live_rows)
-            if new_rows > 0:
-                self._console.print(partial, end="", highlight=False)
-
-        await run_in_terminal(render, render_cli_done=False)
-        self._live_rows = new_rows
+    def compose(self) -> RenderableType | None:
+        if self._writer.has_content():
+            return Group(self._writer.render_partial(), self._spinner)
+        return self._spinner
 
     async def _commit_text_line(self) -> None:
         if self._writer.can_commit():
@@ -173,38 +174,25 @@ class _StreamPrinter:
             flushed = self._writer.flush()
             if flushed is not None:
                 def render() -> None:
-                    self._rewind_live_text(self._live_rows)
-                    self._console.print(flushed, end="")
-                    self._console.print("", highlight=False)
-                await run_in_terminal(render, render_cli_done=False)
-                self._live_rows = 0
-        elif self._live_rows:
-            def render() -> None:
-                self._rewind_live_text(self._live_rows)
-            await run_in_terminal(render, render_cli_done=False)
-            self._live_rows = 0
+                    self._console.print(flushed)
+                await self._run_in_terminal(render)
+        self._invalidate()
 
     async def commit_live_text(self) -> None:
-        if self._writer.has_content() or self._live_rows:
+        if self._writer.has_content():
             await self._commit_text_line()
 
-    def _rewind_live_text(self, rows: int) -> None:
-        if rows <= 0:
-            return
-        output = getattr(self._console, "file", None)
-        if output is None:
-            return
-        output.write(f"\x1b[{rows}A\r")
-        for row in range(rows):
-            output.write("\x1b[2K")
-            if row < rows - 1:
-                output.write("\x1b[1B\r")
-        if rows > 1:
-            output.write(f"\x1b[{rows - 1}A\r")
-        output.flush()
-
     async def _print(self, *args: Any, **kwargs: Any) -> None:
-        await run_in_terminal(lambda: self._console.print(*args, **kwargs), render_cli_done=False)
+        await self._run_in_terminal(lambda: self._console.print(*args, **kwargs))
+
+    async def _run_in_terminal(self, function: Callable[[], None]) -> None:
+        def write_directly() -> None:
+            with direct_terminal_stdio():
+                function()
+
+        with synchronized_prompt_output():
+            await run_in_terminal(write_directly, render_cli_done=False)
+            await restore_synchronized_prompt()
 
 
 class _CliToolCallReporter:
@@ -283,12 +271,7 @@ class CliChannel(Interface):
         while not self._stop_event.is_set():
             try:
                 with patch_stdout(raw=True):
-                    raw = (
-                        await self._prompt.prompt_async(
-                            self._prompt_message,
-                            refresh_interval=_PROMPT_REFRESH_INTERVAL,
-                        )
-                    ).strip()
+                    raw = (await self._prompt.prompt_async(self._prompt_message)).strip()
             except KeyboardInterrupt:
                 self._renderer.info("Interrupted. Use ',quit' to exit.")
                 continue
@@ -340,8 +323,17 @@ class CliChannel(Interface):
             return raw
         return f",{raw}"
 
-    def _prompt_message(self) -> FormattedText:
+    def _prompt_message(self) -> AnyFormattedText:
         prompt = self._prompt_label()
+        stream_printer = getattr(self, "_stream_printer", None)
+        if stream_printer is not None:
+            renderable = stream_printer.compose()
+            if renderable is not None:
+                agent_ansi = render_to_ansi(renderable, width=get_console().width).rstrip("\n")
+                return merge_formatted_text([
+                    ANSI(agent_ansi),
+                    FormattedText([("bold", f"\n{prompt}")]),
+                ])
         if not self._llm_loop_running:
             return FormattedText([("bold", prompt)])
         index = int(monotonic() / _PROMPT_REFRESH_INTERVAL) % len(_GENERATION_SPINNER)
@@ -370,8 +362,10 @@ class CliChannel(Interface):
             console=console,
             print_head=lambda: self._renderer.print_head(message.kind),
             expand_thinking=self._expand_thinking,
+            invalidate=self._invalidate_prompt,
         )
         self._stream_printer = printer
+        self._invalidate_prompt()
         try:
             with tool_call_reporter(_CliToolCallReporter(self._renderer)):
                 async for event in stream:
@@ -380,6 +374,7 @@ class CliChannel(Interface):
         finally:
             if self._stream_printer is printer:
                 self._stream_printer = None
+                self._invalidate_prompt()
 
     def _build_prompt(self, workspace: Path) -> PromptSession[str]:
         kb = KeyBindings()
@@ -398,14 +393,17 @@ class CliChannel(Interface):
         history = FileHistory(str(history_file))
         tool_names = sorted([*(f",{name}" for name in REGISTRY), ",thinking"], key=_tool_sort_key)
         completer = WordCompleter(tool_names, ignore_case=True, sentence=True)
-        return PromptSession(
+        prompt: PromptSession[str] = PromptSession(
             completer=completer,
             complete_while_typing=True,
             key_bindings=kb,
             history=history,
             bottom_toolbar=self._render_bottom_toolbar,
             erase_when_done=True,
+            output=create_synchronized_output(),
         )
+        prompt.app.min_redraw_interval = _PROMPT_REFRESH_INTERVAL
+        return prompt
 
     def _render_bottom_toolbar(self) -> FormattedText:
         info = self._last_tape_info

--- a/src/bub/channels/cli/ansi_bridge.py
+++ b/src/bub/channels/cli/ansi_bridge.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import re
+from io import StringIO
+
+from rich.console import Console, RenderableType
+
+# prompt_toolkit's ANSI parser does not understand OSC 8 hyperlinks. Marking
+# each OSC sequence as zero-width preserves the link without affecting layout.
+_OSC8_RE = re.compile(r"\x1b\]8;[^\x07\x1b]*(?:\x1b\\|\x07)")
+
+
+def render_to_ansi(renderable: RenderableType, *, width: int | None = None) -> str:
+    """Render a Rich object as ANSI text consumable by prompt_toolkit."""
+    output = StringIO()
+    console = Console(
+        file=output,
+        force_terminal=True,
+        highlight=False,
+        width=width,
+    )
+    console.print(renderable, end="")
+    return _OSC8_RE.sub(lambda match: f"\x01{match.group(0)}\x02", output.getvalue())

--- a/src/bub/channels/cli/terminal_output.py
+++ b/src/bub/channels/cli/terminal_output.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import sys
+from collections.abc import Iterator
+from contextlib import contextmanager, redirect_stderr, redirect_stdout
+from typing import TextIO, cast
+
+from prompt_toolkit.application import get_app_or_none
+from prompt_toolkit.output.base import Output
+from prompt_toolkit.output.vt100 import Vt100_Output
+
+_BEGIN_SYNCHRONIZED_UPDATE = "\x1b[?2026h"
+_END_SYNCHRONIZED_UPDATE = "\x1b[?2026l"
+
+
+class SynchronizedVt100Output(Vt100_Output):
+    """VT100 output that presents each rendered frame atomically."""
+
+    _synchronized_depth = 0
+
+    def flush(self) -> None:
+        if not self._buffer:
+            return
+        if self._synchronized_depth == 0:
+            self._buffer.insert(0, _BEGIN_SYNCHRONIZED_UPDATE)
+            self._buffer.append(_END_SYNCHRONIZED_UPDATE)
+        super().flush()
+
+    @contextmanager
+    def synchronized_update(self) -> Iterator[None]:
+        if self._synchronized_depth == 0:
+            self.write_raw(_BEGIN_SYNCHRONIZED_UPDATE)
+            super().flush()
+        self._synchronized_depth += 1
+        try:
+            yield
+        finally:
+            self._synchronized_depth -= 1
+            if self._synchronized_depth == 0:
+                self.write_raw(_END_SYNCHRONIZED_UPDATE)
+                super().flush()
+
+
+def create_synchronized_output(stdout: TextIO | None = None) -> Output | None:
+    target = stdout if stdout is not None else sys.stdout
+    if sys.platform == "win32" or not target.isatty():
+        return None
+    return cast(SynchronizedVt100Output, SynchronizedVt100Output.from_pty(target))
+
+
+def _original_stream(stream: TextIO) -> TextIO:
+    original = getattr(stream, "original_stdout", None)
+    return cast(TextIO, original) if original is not None else stream
+
+
+@contextmanager
+def direct_terminal_stdio() -> Iterator[None]:
+    """Bypass prompt_toolkit's deferred stdout proxy for an active terminal callback."""
+    with redirect_stdout(_original_stream(sys.stdout)), redirect_stderr(_original_stream(sys.stderr)):
+        yield
+
+
+async def restore_synchronized_prompt() -> None:
+    """Finish the CPR-dependent toolbar redraw before presenting a synchronized frame."""
+    app = get_app_or_none()
+    if app is None or not app.is_running or not isinstance(app.output, SynchronizedVt100Output):
+        return
+    if app.renderer.waiting_for_cpr:
+        await app.renderer.wait_for_cpr_responses()
+    if app.is_running and not app.is_done and app.renderer.height_is_known:
+        # We are on the application loop; a direct redraw keeps this frame inside
+        # the synchronized-output context instead of waiting for the redraw throttle.
+        app._redraw()
+
+
+@contextmanager
+def synchronized_prompt_output() -> Iterator[None]:
+    app = get_app_or_none()
+    output = app.output if app is not None else None
+    if isinstance(output, SynchronizedVt100Output):
+        with output.synchronized_update():
+            yield
+        return
+    yield

--- a/src/bub/channels/cli/writers.py
+++ b/src/bub/channels/cli/writers.py
@@ -1,0 +1,231 @@
+"""Streaming text rendering strategies for CLI output.
+
+This module provides pluggable writers that control how streaming text
+from model responses is formatted and committed to the terminal.
+
+- ``PlainTextWriter``: line-based plain text (original bub behavior)
+- ``MarkdownWriter``: block-based Markdown with incremental commitment
+"""
+
+from __future__ import annotations
+
+import io
+from typing import Any, Protocol, runtime_checkable
+
+from rich.console import Console
+from rich.markdown import Markdown
+from rich.text import Text
+
+
+@runtime_checkable
+class StreamWriter(Protocol):
+    """Protocol for streaming text rendering strategies.
+
+    A StreamWriter accumulates text deltas and decides when content is
+    ready to be permanently committed vs. kept in a re-renderable live area.
+    """
+
+    def append(self, text: str) -> None:
+        """Accumulate a text delta."""
+        ...
+
+    def can_commit(self) -> bool:
+        """Return True when committable content is ready."""
+        ...
+
+    def render_committed(self) -> Any:
+        """Return a renderable for the next committable content."""
+        ...
+
+    def render_partial(self) -> Any:
+        """Return a renderable for current live (uncommitted) content."""
+        ...
+
+    def commit(self) -> bool:
+        """Advance past committed content. Returns True if content was committed."""
+        ...
+
+    def flush(self) -> Any | None:
+        """Force-commit all remaining content. Returns renderable or None."""
+        ...
+
+    def has_content(self) -> bool:
+        """Return True if there is any uncommitted content."""
+        ...
+
+    def reset(self) -> None:
+        """Reset to initial empty state."""
+        ...
+
+    def row_count(self, renderable: Any, console_width: int) -> int:
+        """Calculate terminal rows needed for a renderable."""
+        ...
+
+
+class PlainTextWriter:
+    """Line-based plain text writer.
+
+    Commits on newline boundaries. Each completed line becomes permanently
+    printed text. The incomplete tail is re-rendered on each delta.
+    """
+
+    def __init__(self) -> None:
+        self._buffer = ""
+        self._committed_up_to = 0
+
+    def append(self, text: str) -> None:
+        self._buffer += text
+
+    def can_commit(self) -> bool:
+        return "\n" in self._buffer[self._committed_up_to:]
+
+    def render_committed(self) -> str:
+        uncommitted = self._buffer[self._committed_up_to:]
+        last_nl = uncommitted.rfind("\n")
+        return uncommitted[: last_nl + 1]
+
+    def render_partial(self) -> str:
+        uncommitted = self._buffer[self._committed_up_to:]
+        last_nl = uncommitted.rfind("\n")
+        return uncommitted[last_nl + 1:]
+
+    def commit(self) -> bool:
+        uncommitted = self._buffer[self._committed_up_to:]
+        last_nl = uncommitted.rfind("\n")
+        if last_nl < 0:
+            return False
+        self._committed_up_to += last_nl + 1
+        return True
+
+    def flush(self) -> str | None:
+        remaining = self._buffer[self._committed_up_to:]
+        if not remaining:
+            return None
+        self._committed_up_to = len(self._buffer)
+        return remaining + "\n"
+
+    def has_content(self) -> bool:
+        return bool(self._buffer[self._committed_up_to:])
+
+    def reset(self) -> None:
+        self._buffer = ""
+        self._committed_up_to = 0
+
+    def row_count(self, renderable: Any, console_width: int) -> int:
+        text = str(renderable).rstrip("\n")
+        if not text:
+            return 0
+        from prompt_toolkit.utils import get_cwidth
+
+        columns = max(1, console_width)
+        return max(1, (get_cwidth(text) + columns - 1) // columns)
+
+
+class MarkdownWriter:
+    """Block-based Markdown writer with incremental commitment.
+
+    Commits completed top-level blocks (separated by blank lines) via
+    ``rich.Markdown``. The incomplete tail is re-rendered on each delta.
+
+    Fence-aware: strips incomplete closing fences from the live area
+    to prevent code block flicker.
+    """
+
+    def __init__(self) -> None:
+        self._buffer = ""
+        self._committed_text = ""
+        self._to_commit = ""
+        self._partial = ""
+
+    def append(self, text: str) -> None:
+        self._buffer += text
+        self._reparse()
+
+    def _reparse(self) -> None:
+        uncommitted = self._buffer[len(self._committed_text):]
+        segments = uncommitted.split("\n\n")
+        fence_count = sum(s.count("```") for s in segments)
+
+        if fence_count % 2 == 0:
+            self._to_commit = uncommitted
+            self._partial = ""
+        else:
+            if len(segments) > 1:
+                self._to_commit = "\n\n".join(segments[:-1]) + "\n\n"
+                self._partial = segments[-1]
+            else:
+                self._to_commit = ""
+                self._partial = segments[0] if segments else ""
+
+    def can_commit(self) -> bool:
+        return bool(self._to_commit) and bool(self._to_commit.strip())
+
+    def render_committed(self) -> Markdown:
+        return Markdown(self._to_commit.rstrip())
+
+    def render_partial(self) -> Markdown | Text:
+        if not self._partial.strip():
+            return Text("")
+        content = _trim_partial_closing_fences(self._partial)
+        if not content.strip():
+            return Text(content)
+        return Markdown(content)
+
+    def commit(self) -> bool:
+        if not self.can_commit():
+            return False
+        self._committed_text += self._to_commit
+        self._to_commit = ""
+        return True
+
+    def flush(self) -> Markdown | None:
+        uncommitted = self._buffer[len(self._committed_text):]
+        if not uncommitted.strip():
+            return None
+        self._committed_text = self._buffer
+        self._to_commit = ""
+        self._partial = ""
+        return Markdown(uncommitted.rstrip())
+
+    def has_content(self) -> bool:
+        uncommitted = self._buffer[len(self._committed_text):]
+        return bool(uncommitted.strip())
+
+    def reset(self) -> None:
+        self._buffer = ""
+        self._committed_text = ""
+        self._to_commit = ""
+        self._partial = ""
+
+    def row_count(self, renderable: Any, console_width: int) -> int:
+        if not renderable or (isinstance(renderable, Text) and not str(renderable).strip()):
+            return 0
+        tmp = Console(
+            file=io.StringIO(),
+            width=console_width,
+            force_terminal=True,
+            color_system=None,
+        )
+        with tmp.capture() as captured:
+            tmp.print(renderable, end="")
+        lines = captured.get().split("\n")
+        while lines and not lines[-1].strip():
+            lines.pop()
+        return max(1, len(lines)) if lines else 0
+
+
+def _trim_partial_closing_fences(text: str) -> str:
+    """Strip incomplete closing fences to prevent code block flicker.
+
+    When streaming, a closing ``` may arrive before the next delta extends
+    past it, causing rich.Markdown to briefly close and reopen the block.
+    This detects an unclosed code block (odd ``` count) and strips the
+    trailing incomplete fence.
+    """
+    fence_count = text.count("```")
+    if fence_count % 2 == 0:
+        return text
+    last_fence = text.rfind("```")
+    if last_fence < 0:
+        return text
+    return text[:last_fence].rstrip()

--- a/src/bub/channels/cli/writers.py
+++ b/src/bub/channels/cli/writers.py
@@ -10,11 +10,48 @@ from model responses is formatted and committed to the terminal.
 from __future__ import annotations
 
 import io
+import re
 from typing import Any, Protocol, runtime_checkable
 
 from rich.console import Console
 from rich.markdown import Markdown
 from rich.text import Text
+
+_MARKDOWN_CODE_THEME = "ansi_dark"
+_FENCE_START_RE = re.compile(r"^ {0,3}(`{3,}|~{3,})(.*)$")
+
+
+def _markdown(content: str) -> Markdown:
+    return Markdown(content, code_theme=_MARKDOWN_CODE_THEME)
+
+
+def _committable_prefix_length(content: str) -> int:
+    """Return the last completed blank-line boundary outside fenced code."""
+    boundary = 0
+    offset = 0
+    fence_char: str | None = None
+    fence_length = 0
+
+    for line in content.splitlines(keepends=True):
+        body = line.rstrip("\r\n")
+        if fence_char is None:
+            match = _FENCE_START_RE.match(body)
+            if match is not None and not (match.group(1)[0] == "`" and "`" in match.group(2)):
+                marker = match.group(1)
+                fence_char = marker[0]
+                fence_length = len(marker)
+            elif not body.strip() and line.endswith(("\n", "\r")):
+                boundary = offset + len(line)
+        else:
+            stripped = body.lstrip(" ")
+            indent = len(body) - len(stripped)
+            marker_length = len(stripped) - len(stripped.lstrip(fence_char))
+            if indent <= 3 and marker_length >= fence_length and not stripped[marker_length:].strip():
+                fence_char = None
+                fence_length = 0
+        offset += len(line)
+
+    return boundary
 
 
 @runtime_checkable
@@ -127,8 +164,8 @@ class MarkdownWriter:
     Commits completed top-level blocks (separated by blank lines) via
     ``rich.Markdown``. The incomplete tail is re-rendered on each delta.
 
-    Fence-aware: strips incomplete closing fences from the live area
-    to prevent code block flicker.
+    Fence-aware: keeps an open fenced code block in the live area so Rich can
+    render and highlight it before the closing fence arrives.
     """
 
     def __init__(self) -> None:
@@ -143,33 +180,20 @@ class MarkdownWriter:
 
     def _reparse(self) -> None:
         uncommitted = self._buffer[len(self._committed_text):]
-        segments = uncommitted.split("\n\n")
-        fence_count = sum(s.count("```") for s in segments)
-
-        if fence_count % 2 == 0:
-            self._to_commit = uncommitted
-            self._partial = ""
-        else:
-            if len(segments) > 1:
-                self._to_commit = "\n\n".join(segments[:-1]) + "\n\n"
-                self._partial = segments[-1]
-            else:
-                self._to_commit = ""
-                self._partial = segments[0] if segments else ""
+        split_at = _committable_prefix_length(uncommitted)
+        self._to_commit = uncommitted[:split_at]
+        self._partial = uncommitted[split_at:]
 
     def can_commit(self) -> bool:
         return bool(self._to_commit) and bool(self._to_commit.strip())
 
     def render_committed(self) -> Markdown:
-        return Markdown(self._to_commit.rstrip())
+        return _markdown(self._to_commit.rstrip())
 
     def render_partial(self) -> Markdown | Text:
         if not self._partial.strip():
             return Text("")
-        content = _trim_partial_closing_fences(self._partial)
-        if not content.strip():
-            return Text(content)
-        return Markdown(content)
+        return _markdown(self._partial)
 
     def commit(self) -> bool:
         if not self.can_commit():
@@ -185,7 +209,7 @@ class MarkdownWriter:
         self._committed_text = self._buffer
         self._to_commit = ""
         self._partial = ""
-        return Markdown(uncommitted.rstrip())
+        return _markdown(uncommitted.rstrip())
 
     def has_content(self) -> bool:
         uncommitted = self._buffer[len(self._committed_text):]
@@ -212,20 +236,3 @@ class MarkdownWriter:
         while lines and not lines[-1].strip():
             lines.pop()
         return max(1, len(lines)) if lines else 0
-
-
-def _trim_partial_closing_fences(text: str) -> str:
-    """Strip incomplete closing fences to prevent code block flicker.
-
-    When streaming, a closing ``` may arrive before the next delta extends
-    past it, causing rich.Markdown to briefly close and reopen the block.
-    This detects an unclosed code block (odd ``` count) and strips the
-    trailing incomplete fence.
-    """
-    fence_count = text.count("```")
-    if fence_count % 2 == 0:
-        return text
-    last_fence = text.rfind("```")
-    if last_fence < 0:
-        return text
-    return text[:last_fence].rstrip()

--- a/tests/test_ansi_bridge.py
+++ b/tests/test_ansi_bridge.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from prompt_toolkit.formatted_text import ANSI, to_formatted_text
+from rich.console import Group
+from rich.markdown import Markdown
+from rich.style import Style
+from rich.text import Text
+
+from bub.channels.cli.ansi_bridge import render_to_ansi
+
+
+def _visible_text(value: str) -> str:
+    return "".join(
+        fragment[1]
+        for fragment in to_formatted_text(ANSI(value))
+        if "[ZeroWidthEscape]" not in fragment[0]
+    )
+
+
+def test_render_to_ansi_renders_markdown_and_groups(monkeypatch) -> None:
+    monkeypatch.setenv("TERM", "xterm-256color")
+
+    rendered = render_to_ansi(
+        Group(Markdown("**first**"), Text("second", style="green")),
+        width=40,
+    )
+
+    visible = _visible_text(rendered)
+    assert "first" in visible
+    assert "second" in visible
+    assert visible.index("first") < visible.index("second")
+    assert "\x1b[" in rendered
+
+
+def test_render_to_ansi_marks_osc8_links_as_zero_width(monkeypatch) -> None:
+    monkeypatch.setenv("TERM", "xterm-256color")
+
+    rendered = render_to_ansi(
+        Text("OpenAI", style=Style(link="https://openai.com")),
+        width=40,
+    )
+    fragments = to_formatted_text(ANSI(rendered))
+
+    zero_width = [fragment[1] for fragment in fragments if "[ZeroWidthEscape]" in fragment[0]]
+    assert len(zero_width) == 2
+    assert zero_width[0].startswith("\x1b]8;")
+    assert "https://openai.com" in zero_width[0]
+    assert zero_width[1].startswith("\x1b]8;;")
+    assert _visible_text(rendered) == "OpenAI"
+
+
+def test_render_to_ansi_honors_width_for_ascii_and_cjk(monkeypatch) -> None:
+    monkeypatch.setenv("TERM", "xterm-256color")
+
+    ascii_lines = _visible_text(render_to_ansi(Text("1234567890"), width=4)).splitlines()
+    cjk_lines = _visible_text(render_to_ansi(Text("春风一夜入江城"), width=6)).splitlines()
+
+    assert ascii_lines == ["1234", "5678", "90"]
+    assert cjk_lines == ["春风一", "夜入江", "城"]
+
+
+def test_render_to_ansi_accepts_default_width() -> None:
+    assert "hello" in _visible_text(render_to_ansi(Text("hello")))

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -929,7 +929,13 @@ async def test_cli_channel_stream_events_prints_stream_and_yields_events(monkeyp
     yielded = [event async for event in channel.stream_events(message, source())]
 
     assert heads == ["command"]
-    assert printed == [("hel\n", "", False), ("hello\n", "", False)]
+    # MarkdownWriter is default — check that Markdown objects or plain text were printed
+    from rich.markdown import Markdown
+
+    all_text = " ".join(
+        item.markup if isinstance(item, Markdown) else str(item) for item, *_ in printed
+    )
+    assert "hel" in all_text or "hello" in all_text
     assert [event.kind for event in yielded] == ["text", "text", "final"]
 
 
@@ -943,6 +949,7 @@ def test_cli_stream_output_does_not_overlap_active_pty_prompt() -> None:
         from rich.console import Console
 
         from bub.channels.cli import _StreamPrinter
+        from bub.channels.cli.writers import PlainTextWriter
         from bub.streaming import StreamEvent
 
 
@@ -952,6 +959,7 @@ def test_cli_stream_output_does_not_overlap_active_pty_prompt() -> None:
                 console=console,
                 print_head=lambda: console.print("Assistant >"),
                 expand_thinking=False,
+                writer=PlainTextWriter(),
             )
             session = PromptSession(erase_when_done=True)
 
@@ -1072,7 +1080,12 @@ async def test_cli_channel_collapsed_reasoning_does_not_start_status_spinner(
 
     assert [event.kind for event in yielded] == ["reasoning", "text", "final"]
     assert printed
-    assert any("hello" in str(item) for item in printed)
+    from rich.markdown import Markdown
+
+    assert any(
+        "hello" in (item.markup if isinstance(item, Markdown) else str(item))
+        for item in printed
+    )
 
 
 def test_cli_channel_history_file_uses_workspace_hash(tmp_path: Path) -> None:

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -29,6 +29,7 @@ from bub.streaming import StreamEvent
 from bub.turn import TurnResult
 
 ANSI_RE = re.compile(r"\x1b(?:\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1b\\)|[()][A-Za-z])")
+_PTY_PROCESS_TIMEOUT = 15.0
 
 
 def _load_channel_config(
@@ -47,7 +48,12 @@ telegram:
     load_config(content)
 
 
-def _read_pty_until_exit(master_fd: int, process: subprocess.Popen[bytes], *, timeout: float = 3.0) -> bytes:
+def _read_pty_until_exit(
+    master_fd: int,
+    process: subprocess.Popen[bytes],
+    *,
+    timeout: float = _PTY_PROCESS_TIMEOUT,
+) -> bytes:
     chunks: list[bytes] = []
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
@@ -71,6 +77,28 @@ def _read_pty_until_exit(master_fd: int, process: subprocess.Popen[bytes], *, ti
 def _plain_terminal_text(raw: bytes) -> str:
     text = raw.decode(errors="replace")
     return ANSI_RE.sub("", text).replace("\r", "\n")
+
+
+def _assert_cursor_updates_are_synchronized(raw: bytes) -> None:
+    depth = 0
+    synchronized_frames = 0
+    pattern = re.compile(rb"\x1b\[\?(?:2026|25|12)[hl]")
+    for match in pattern.finditer(raw):
+        sequence = match.group()
+        if sequence == b"\x1b[?2026h":
+            depth += 1
+            synchronized_frames += 1
+        elif sequence == b"\x1b[?2026l":
+            depth -= 1
+            assert depth >= 0
+        else:
+            assert depth > 0, f"cursor update outside synchronized frame: {sequence!r}"
+    assert synchronized_frames > 0
+    assert depth == 0
+
+
+def _synchronized_frames(raw: bytes) -> list[bytes]:
+    return re.findall(rb"\x1b\[\?2026h(.*?)\x1b\[\?2026l", raw, flags=re.DOTALL)
 
 
 class _FakeChannelMixin:
@@ -392,10 +420,9 @@ async def test_cli_channel_accepts_input_while_previous_message_is_running() -> 
 
     await asyncio.wait_for(channel._main_loop(), timeout=1)
 
-    import bub.channels.cli as cli_module
 
     assert [message.content for message in received] == ["first", "second"]
-    assert channel._prompt.refresh_intervals == [cli_module._PROMPT_REFRESH_INTERVAL] * 3
+    assert channel._prompt.refresh_intervals == [None] * 3
     assert channel._prompt.received_callables == [True, True, True]
     assert "Generating\n" not in channel._prompt.messages[0]
     assert "Generating\n" in channel._prompt.messages[1]
@@ -405,12 +432,20 @@ async def test_cli_channel_accepts_input_while_previous_message_is_running() -> 
 
 def test_cli_channel_build_prompt_erases_submitted_prompt(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     captured: dict[str, object] = {}
+    fake_app = SimpleNamespace(min_redraw_interval=None)
+    synchronized_output = object()
 
     class FakePromptSession:
         def __init__(self, **kwargs) -> None:
             captured.update(kwargs)
+            self.app = fake_app
 
     monkeypatch.setattr("bub.channels.cli.PromptSession", FakePromptSession)
+    monkeypatch.setattr(
+        "bub.channels.cli.create_synchronized_output",
+        lambda: synchronized_output,
+        raising=False,
+    )
     channel = CliChannel.__new__(CliChannel)
     channel._mode = "agent"
     channel._expand_thinking = False
@@ -421,11 +456,14 @@ def test_cli_channel_build_prompt_erases_submitted_prompt(monkeypatch: pytest.Mo
 
     assert isinstance(prompt, FakePromptSession)
     assert captured["erase_when_done"] is True
+    assert captured["output"] is synchronized_output
+    assert fake_app.min_redraw_interval == pytest.approx(0.08)
 
 
 def test_cli_channel_generating_spinner_renders_above_input_not_toolbar(monkeypatch: pytest.MonkeyPatch) -> None:
     channel = CliChannel.__new__(CliChannel)
     channel._llm_loop_running = True
+    channel._stream_printer = None
     channel._mode = "agent"
     channel._expand_thinking = False
     channel._last_tape_info = None
@@ -447,6 +485,110 @@ def test_cli_channel_generating_spinner_renders_above_input_not_toolbar(monkeypa
     second_frame = "".join(part for _, part in channel._prompt_message())
 
     assert first_frame != second_frame
+
+
+def test_cli_channel_stream_delegate_renders_partial_above_prompt(monkeypatch: pytest.MonkeyPatch) -> None:
+    from prompt_toolkit.formatted_text import to_formatted_text
+    from rich.text import Text
+
+    channel = CliChannel.__new__(CliChannel)
+    channel._llm_loop_running = True
+    channel._mode = "agent"
+    channel._stream_printer = SimpleNamespace(compose=lambda: Text("partial response", style="green"))
+    monkeypatch.setattr("bub.channels.cli.get_console", lambda: SimpleNamespace(width=80))
+
+    fragments = to_formatted_text(channel._prompt_message())
+    visible = "".join(fragment[1] for fragment in fragments if "[ZeroWidthEscape]" not in fragment[0])
+
+    assert "partial response" in visible
+    assert visible.index("partial response") < visible.index(channel._prompt_label())
+
+
+@pytest.mark.asyncio
+async def test_stream_printer_commits_complete_blocks_and_keeps_only_partial_dynamic(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from io import StringIO
+
+    from prompt_toolkit.formatted_text import ANSI, to_formatted_text
+    from rich.console import Console
+
+    from bub.channels.cli import _StreamPrinter
+    from bub.channels.cli.ansi_bridge import render_to_ansi
+
+    async def run_immediately(func, render_cli_done=True):
+        func()
+
+    monkeypatch.setattr("bub.channels.cli.run_in_terminal", run_immediately)
+    output = StringIO()
+    invalidations: list[None] = []
+    printer = _StreamPrinter(
+        console=Console(file=output, width=80, force_terminal=True, color_system=None),
+        print_head=lambda: None,
+        expand_thinking=False,
+        invalidate=lambda: invalidations.append(None),
+    )
+
+    await printer.render(StreamEvent("text", {"delta": "First block\n\nSecond block"}))
+
+    permanent = output.getvalue()
+    dynamic_ansi = render_to_ansi(printer.compose(), width=80)
+    dynamic = "".join(
+        fragment[1]
+        for fragment in to_formatted_text(ANSI(dynamic_ansi))
+        if "[ZeroWidthEscape]" not in fragment[0]
+    )
+    assert "First block" in permanent
+    assert "Second block" not in permanent
+    assert "First block" not in dynamic
+    assert "Second block" in dynamic
+    assert invalidations
+
+    await printer.render(StreamEvent("final", {}))
+
+    assert output.getvalue().count("First block") == 1
+    assert output.getvalue().count("Second block") == 1
+
+
+@pytest.mark.asyncio
+async def test_stream_printer_bypasses_deferred_stdout_proxy_inside_terminal_callback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from io import StringIO
+
+    from rich.console import Console
+
+    from bub.channels.cli import _StreamPrinter
+
+    class FakeStdoutProxy(StringIO):
+        def __init__(self, original_stdout: StringIO) -> None:
+            super().__init__()
+            self.original_stdout = original_stdout
+
+    direct_output = StringIO()
+    deferred_proxy = FakeStdoutProxy(direct_output)
+    callbacks = 0
+
+    async def run_immediately(function, render_cli_done=True):
+        nonlocal callbacks
+        callbacks += 1
+        function()
+
+    monkeypatch.setattr("bub.channels.cli.run_in_terminal", run_immediately)
+    monkeypatch.setattr("sys.stdout", deferred_proxy)
+    monkeypatch.setattr("sys.stderr", deferred_proxy)
+    console = Console(force_terminal=True, color_system=None, width=80)
+    printer = _StreamPrinter(
+        console=console,
+        print_head=lambda: None,
+        expand_thinking=False,
+    )
+
+    await printer._run_in_terminal(lambda: console.print("committed output"))
+
+    assert callbacks == 1
+    assert deferred_proxy.getvalue() == ""
+    assert "committed output" in direct_output.getvalue()
 
 
 @pytest.mark.asyncio
@@ -906,16 +1048,18 @@ def test_cli_channel_normalize_input_prefixes_shell_commands() -> None:
 
 @pytest.mark.asyncio
 async def test_cli_channel_stream_events_prints_stream_and_yields_events(monkeypatch: pytest.MonkeyPatch) -> None:
+    from io import StringIO
+
+    from rich.console import Console
+
     channel = CliChannel.__new__(CliChannel)
     heads: list[str] = []
-    printed: list[tuple[str, str | None, bool | None]] = []
     channel._renderer = SimpleNamespace(print_head=heads.append)
     channel._expand_thinking = False
+    output = StringIO()
     monkeypatch.setattr(
         "bub.channels.cli.get_console",
-        lambda: SimpleNamespace(
-            print=lambda content, end=None, highlight=None: printed.append((content, end, highlight))
-        ),
+        lambda: Console(file=output, width=80, force_terminal=True, color_system=None),
     )
 
     message = _message("ignored", channel="cli", kind="command", session_id="cli:1")
@@ -929,13 +1073,8 @@ async def test_cli_channel_stream_events_prints_stream_and_yields_events(monkeyp
     yielded = [event async for event in channel.stream_events(message, source())]
 
     assert heads == ["command"]
-    # MarkdownWriter is default — check that Markdown objects or plain text were printed
-    from rich.markdown import Markdown
-
-    all_text = " ".join(
-        item.markup if isinstance(item, Markdown) else str(item) for item, *_ in printed
-    )
-    assert "hel" in all_text or "hello" in all_text
+    captured = output.getvalue()
+    assert "hello" in captured or "hel" in captured
     assert [event.kind for event in yielded] == ["text", "text", "final"]
 
 
@@ -945,23 +1084,37 @@ def test_cli_stream_output_does_not_overlap_active_pty_prompt() -> None:
         import asyncio
 
         from prompt_toolkit import PromptSession
+        from prompt_toolkit.formatted_text import ANSI, FormattedText, merge_formatted_text
         from prompt_toolkit.patch_stdout import patch_stdout
         from rich.console import Console
 
         from bub.channels.cli import _StreamPrinter
+        from bub.channels.cli.ansi_bridge import render_to_ansi
+        from bub.channels.cli.terminal_output import create_synchronized_output
         from bub.channels.cli.writers import PlainTextWriter
         from bub.streaming import StreamEvent
 
 
         async def main():
             console = Console(force_terminal=True, color_system=None, width=80)
+            output = create_synchronized_output()
+            assert output is not None
+            session = PromptSession(erase_when_done=True, output=output)
+            session.app.min_redraw_interval = 0.08
             printer = _StreamPrinter(
                 console=console,
                 print_head=lambda: console.print("Assistant >"),
                 expand_thinking=False,
                 writer=PlainTextWriter(),
+                invalidate=session.app.invalidate,
             )
-            session = PromptSession(erase_when_done=True)
+
+            def prompt_message():
+                body = render_to_ansi(printer.compose(), width=console.width).rstrip("\\n")
+                return merge_formatted_text([
+                    ANSI(body),
+                    FormattedText([("bold", "\\nbub > ")]),
+                ])
 
             async def stream():
                 chunks = [
@@ -984,10 +1137,7 @@ def test_cli_stream_output_does_not_overlap_active_pty_prompt() -> None:
 
             task = asyncio.create_task(stream())
             with patch_stdout(raw=True):
-                await session.prompt_async(
-                    lambda: [("", "\\n* Generating\\nbub > ")],
-                    refresh_interval=0.02,
-                )
+                await session.prompt_async(prompt_message)
             await task
 
 
@@ -1029,6 +1179,202 @@ def test_cli_stream_output_does_not_overlap_active_pty_prompt() -> None:
     assert "bub > steer now" in output
     assert "明朝山色满前庭bub >" not in output
     assert "明朝山色满前庭* Generating" not in output
+    _assert_cursor_updates_are_synchronized(raw_output)
+
+
+def test_cli_stream_markdown_table_renders_in_active_pty_prompt() -> None:
+    script = textwrap.dedent(
+        """
+        import asyncio
+
+        from prompt_toolkit import PromptSession
+        from prompt_toolkit.formatted_text import ANSI, FormattedText, merge_formatted_text
+        from prompt_toolkit.patch_stdout import patch_stdout
+        from rich.console import Console
+
+        from bub.channels.cli import _StreamPrinter
+        from bub.channels.cli.ansi_bridge import render_to_ansi
+        from bub.channels.cli.terminal_output import create_synchronized_output
+        from bub.streaming import StreamEvent
+
+
+        async def main():
+            console = Console(force_terminal=True, color_system=None, width=60)
+            output = create_synchronized_output()
+            assert output is not None
+            session = PromptSession(erase_when_done=True, output=output)
+            session.app.min_redraw_interval = 0.08
+            state = {"printer": None}
+            printer = _StreamPrinter(
+                console=console,
+                print_head=lambda: console.print("Assistant >"),
+                expand_thinking=False,
+                invalidate=session.app.invalidate,
+            )
+            state["printer"] = printer
+
+            def prompt_message():
+                active_printer = state["printer"]
+                if active_printer is None:
+                    return FormattedText([("bold", "bub > ")])
+                body = render_to_ansi(active_printer.compose(), width=console.width).rstrip("\\n")
+                return merge_formatted_text([
+                    ANSI(body),
+                    FormattedText([("bold", "\\nbub > ")]),
+                ])
+
+            async def stream():
+                chunks = [
+                    "| Name | Value |\\n",
+                    "| --- | --- |\\n",
+                    "| café | 42 |\\n\\n",
+                    "After table",
+                ]
+                for chunk in chunks:
+                    await asyncio.sleep(0.04)
+                    await printer.render(StreamEvent("text", {"delta": chunk}))
+                await asyncio.sleep(0.04)
+                await printer.render(StreamEvent("final", {}))
+                state["printer"] = None
+                session.app.invalidate()
+
+            task = asyncio.create_task(stream())
+            with patch_stdout(raw=True):
+                await session.prompt_async(prompt_message)
+            await task
+
+
+        asyncio.run(main())
+        """
+    )
+    master_fd, slave_fd = pty.openpty()
+    env = os.environ.copy()
+    env["PYTHONPATH"] = f"{Path.cwd() / 'src'}{os.pathsep}{env.get('PYTHONPATH', '')}"
+    env["TERM"] = "xterm-256color"
+    process = subprocess.Popen(
+        [sys.executable, "-c", script],
+        stdin=slave_fd,
+        stdout=slave_fd,
+        stderr=slave_fd,
+        cwd=Path.cwd(),
+        env=env,
+        close_fds=True,
+    )
+    os.close(slave_fd)
+    try:
+        time.sleep(0.3)
+        os.write(master_fd, b"next\n")
+        raw_output = _read_pty_until_exit(master_fd, process)
+    finally:
+        if process.poll() is None:
+            process.terminate()
+            with contextlib.suppress(subprocess.TimeoutExpired):
+                process.wait(timeout=1)
+        os.close(master_fd)
+
+    assert process.wait(timeout=1) == 0, raw_output.decode(errors="replace")
+    output = _plain_terminal_text(raw_output)
+
+    assert "Name" in output
+    assert "café" in output
+    assert "42" in output
+    assert "─" in output
+    assert "After table" in output
+    assert "After tablebub >" not in output
+    assert "\x1b" not in output
+    _assert_cursor_updates_are_synchronized(raw_output)
+
+
+def test_cli_committed_output_restores_bottom_toolbar_in_same_frame() -> None:
+    script = textwrap.dedent(
+        """
+        import asyncio
+
+        from prompt_toolkit import PromptSession
+        from prompt_toolkit.patch_stdout import patch_stdout
+        from rich.console import Console
+
+        from bub.channels.cli import _StreamPrinter
+        from bub.channels.cli.terminal_output import create_synchronized_output
+
+
+        async def main():
+            output = create_synchronized_output()
+            assert output is not None
+            console = Console(force_terminal=True, color_system=None, width=80)
+            session = PromptSession(
+                bottom_toolbar="TOOLBAR mode:agent",
+                erase_when_done=True,
+                output=output,
+            )
+            session.app.min_redraw_interval = 0.08
+            printer = _StreamPrinter(
+                console=console,
+                print_head=lambda: None,
+                expand_thinking=False,
+            )
+
+            async def commit_and_exit():
+                await asyncio.sleep(0.2)
+                await printer._run_in_terminal(lambda: console.print("COMMITTED BLOCK"))
+                await asyncio.sleep(0.05)
+                session.app.exit(result="")
+
+            task = asyncio.create_task(commit_and_exit())
+            with patch_stdout(raw=True):
+                await session.prompt_async()
+            await task
+
+
+        asyncio.run(main())
+        """
+    )
+    master_fd, slave_fd = pty.openpty()
+    env = os.environ.copy()
+    env["PYTHONPATH"] = f"{Path.cwd() / 'src'}{os.pathsep}{env.get('PYTHONPATH', '')}"
+    env["TERM"] = "xterm-256color"
+    process = subprocess.Popen(
+        [sys.executable, "-c", script],
+        stdin=slave_fd,
+        stdout=slave_fd,
+        stderr=slave_fd,
+        cwd=Path.cwd(),
+        env=env,
+        close_fds=True,
+    )
+    os.close(slave_fd)
+    raw_output = bytearray()
+    cpr_responses = 0
+    deadline = time.monotonic() + _PTY_PROCESS_TIMEOUT
+    try:
+        while time.monotonic() < deadline:
+            readable, _, _ = select.select([master_fd], [], [], 0.05)
+            if readable:
+                try:
+                    chunk = os.read(master_fd, 65536)
+                except OSError:
+                    break
+                if not chunk:
+                    break
+                raw_output.extend(chunk)
+                requests = raw_output.count(b"\x1b[6n")
+                while cpr_responses < requests:
+                    os.write(master_fd, b"\x1b[1;1R")
+                    cpr_responses += 1
+            if process.poll() is not None:
+                break
+    finally:
+        if process.poll() is None:
+            process.terminate()
+            with contextlib.suppress(subprocess.TimeoutExpired):
+                process.wait(timeout=1)
+        os.close(master_fd)
+
+    captured = bytes(raw_output)
+    assert process.wait(timeout=1) == 0, captured.decode(errors="replace")
+    commit_frames = [frame for frame in _synchronized_frames(captured) if b"COMMITTED BLOCK" in frame]
+    assert len(commit_frames) == 1
+    assert b"TOOLBAR mode:agent" in commit_frames[0]
 
 
 @pytest.mark.asyncio
@@ -1053,21 +1399,21 @@ async def test_cli_channel_input_echo_commits_active_stream_line() -> None:
 async def test_cli_channel_collapsed_reasoning_does_not_start_status_spinner(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    from io import StringIO
+
+    from rich.console import Console
+
     channel = CliChannel.__new__(CliChannel)
     channel._renderer = SimpleNamespace(print_head=lambda kind: None)
     channel._expand_thinking = False
-    printed: list[object] = []
+    output = StringIO()
+    real_console = Console(file=output, width=80, force_terminal=True, color_system=None)
 
     def status(*args, **kwargs):
         raise AssertionError("status spinner should not start while prompt is active")
 
-    monkeypatch.setattr(
-        "bub.channels.cli.get_console",
-        lambda: SimpleNamespace(
-            print=lambda content, end=None, highlight=None: printed.append(content),
-            status=status,
-        ),
-    )
+    monkeypatch.setattr(real_console, "status", status)
+    monkeypatch.setattr("bub.channels.cli.get_console", lambda: real_console)
 
     message = _message("ignored", channel="cli", kind="normal", session_id="cli:1")
 
@@ -1079,13 +1425,9 @@ async def test_cli_channel_collapsed_reasoning_does_not_start_status_spinner(
     yielded = [event async for event in channel.stream_events(message, source())]
 
     assert [event.kind for event in yielded] == ["reasoning", "text", "final"]
-    assert printed
-    from rich.markdown import Markdown
-
-    assert any(
-        "hello" in (item.markup if isinstance(item, Markdown) else str(item))
-        for item in printed
-    )
+    captured = output.getvalue()
+    assert captured
+    assert "hello" in captured
 
 
 def test_cli_channel_history_file_uses_workspace_hash(tmp_path: Path) -> None:

--- a/tests/test_stream_writers.py
+++ b/tests/test_stream_writers.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import pytest
+
+from bub.channels.cli import _StreamPrinter
 from bub.channels.cli.writers import (
     MarkdownWriter,
     PlainTextWriter,
     StreamWriter,
-    _trim_partial_closing_fences,
 )
+from bub.streaming import StreamEvent
 
 
 class TestPlainTextWriter:
@@ -85,10 +88,25 @@ class TestPlainTextWriter:
 
 
 class TestMarkdownWriter:
-    def test_single_paragraph_is_commits(self):
+    @staticmethod
+    def _render_text(writer: MarkdownWriter) -> str:
+        from io import StringIO
+
+        from rich.console import Console
+
+        output = StringIO()
+        Console(file=output, width=80, force_terminal=True, color_system=None).print(writer.render_partial())
+        return output.getvalue()
+
+    def test_single_paragraph_stays_partial_without_blank_line(self):
         w = MarkdownWriter()
         w.append("Hello world")
-        # No unclosed fences → single paragraph is committable
+        assert not w.can_commit()
+        assert "Hello world" in w.render_partial().markup
+
+    def test_single_paragraph_commits_after_blank_line(self):
+        w = MarkdownWriter()
+        w.append("Hello world\n\n")
         assert w.can_commit()
         assert "Hello world" in w.render_committed().markup
 
@@ -104,6 +122,7 @@ class TestMarkdownWriter:
         w.append("Text\n\n```python\ncode here")
         assert w.can_commit()
         assert "Text" in w.render_committed().markup
+        assert "code here" in self._render_text(w)
 
     def test_closed_fence_commits_all(self):
         w = MarkdownWriter()
@@ -139,6 +158,50 @@ class TestMarkdownWriter:
         w.append("```\n\nDone!")
         assert w.can_commit()
 
+    def test_unclosed_code_block_renders_each_streamed_update(self):
+        w = MarkdownWriter()
+        w.append("```python\n")
+
+        w.append("def greet")
+        assert "def greet" in self._render_text(w)
+
+        w.append("(name):\n")
+        assert "def greet(name):" in self._render_text(w)
+
+        w.append('    return f"Hello, {name}"')
+        rendered = self._render_text(w)
+        assert "def greet(name):" in rendered
+        assert 'return f"Hello, {name}"' in rendered
+
+    def test_blank_line_inside_fence_is_not_a_commit_boundary(self):
+        w = MarkdownWriter()
+        code = "```python\ndef first():\n    return 1\n\ndef second():\n    return 2\n```"
+
+        w.append(code)
+
+        assert not w.can_commit()
+        rendered = self._render_text(w)
+        assert "def first():" in rendered
+        assert "def second():" in rendered
+
+        w.append("\n\nAfter code")
+
+        assert w.can_commit()
+        assert w.render_committed().markup == code
+        assert "After code" in w.render_partial().markup
+
+    def test_code_highlighting_does_not_set_background_color(self):
+        from rich.console import Console
+
+        w = MarkdownWriter()
+        w.append("```python\ndef greet():\n    return 42")
+
+        segments = list(Console(width=80, force_terminal=True, color_system="standard").render(w.render_partial()))
+        code_segments = [segment for segment in segments if segment.text.strip()]
+
+        assert any(segment.style and segment.style.color is not None for segment in code_segments)
+        assert all(segment.style is None or segment.style.bgcolor is None for segment in code_segments)
+
     def test_reset(self):
         w = MarkdownWriter()
         w.append("hello\n\nworld")
@@ -156,25 +219,43 @@ class TestMarkdownWriter:
         assert w.row_count(Text(""), 80) == 0
 
 
-class TestTrimPartialClosingFences:
-    def test_strips_unclosed_fence(self):
-        text = "```python\ncode\n```"
-        result = _trim_partial_closing_fences(text)
-        assert result.count("```") % 2 == 0
+class TestStreamPrinterIntegration:
+    @pytest.mark.asyncio
+    async def test_no_commit_per_token_without_block_boundary(self, monkeypatch):
+        import asyncio
+        from io import StringIO
 
-    def test_preserves_paired_fences(self):
-        text = "```python\ncode\n```\n\n```bash\nmore"
-        result = _trim_partial_closing_fences(text)
-        assert result.count("```") == 2
+        from rich.console import Console
 
-    def test_no_fences_unchanged(self):
-        text = "Just plain text"
-        assert _trim_partial_closing_fences(text) == text
+        async def fake_run_in_terminal(func, render_cli_done=True):
+            if asyncio.iscoroutine(func):
+                await func
+            elif callable(func):
+                func()
+            return None
 
-    def test_empty_string(self):
-        assert _trim_partial_closing_fences("") == ""
+        monkeypatch.setattr("bub.channels.cli.run_in_terminal", fake_run_in_terminal)
 
-    def test_single_open_fence(self):
-        text = "```python\ndef hello():"
-        result = _trim_partial_closing_fences(text)
-        assert "```" not in result
+        console = Console(file=StringIO(), width=80, force_terminal=True, color_system=None)
+        printer = _StreamPrinter(
+            console=console,
+            print_head=lambda: None,
+            expand_thinking=False,
+        )
+        commits = 0
+        real_commit = printer._writer.commit
+
+        def spy_commit():
+            nonlocal commits
+            committed = real_commit()
+            if committed:
+                commits += 1
+            return committed
+
+        printer._writer.commit = spy_commit
+
+        for ch in "春风一夜入江城":
+            await printer.render(StreamEvent("text", {"delta": ch}))
+        await printer.render(StreamEvent("final", {}))
+
+        assert commits == 0

--- a/tests/test_stream_writers.py
+++ b/tests/test_stream_writers.py
@@ -1,0 +1,180 @@
+"""Unit tests for streaming text writers."""
+
+from __future__ import annotations
+
+from bub.channels.cli.writers import (
+    MarkdownWriter,
+    PlainTextWriter,
+    StreamWriter,
+    _trim_partial_closing_fences,
+)
+
+
+class TestPlainTextWriter:
+    def test_cannot_commit_without_newline(self):
+        w = PlainTextWriter()
+        w.append("hello")
+        assert not w.can_commit()
+
+    def test_can_commit_with_newline(self):
+        w = PlainTextWriter()
+        w.append("hello\n")
+        assert w.can_commit()
+
+    def test_splits_on_newline(self):
+        w = PlainTextWriter()
+        w.append("hello\nworld")
+        assert w.render_committed() == "hello\n"
+        assert w.render_partial() == "world"
+
+    def test_commit_advances_state(self):
+        w = PlainTextWriter()
+        w.append("line1\nline2\nline3")
+        assert w.render_committed() == "line1\nline2\n"
+        w.commit()
+        assert w.render_partial() == "line3"
+        assert not w.can_commit()
+
+    def test_flush_adds_trailing_newline(self):
+        w = PlainTextWriter()
+        w.append("partial")
+        assert w.flush() == "partial\n"
+        assert not w.has_content()
+
+    def test_flush_returns_none_when_empty(self):
+        w = PlainTextWriter()
+        assert w.flush() is None
+
+    def test_streaming_simulation(self):
+        w = PlainTextWriter()
+        w.append("hel")
+        assert not w.can_commit()
+        w.append("lo\nwor")
+        assert w.can_commit()
+        assert w.render_committed() == "hello\n"
+        assert w.render_partial() == "wor"
+        w.commit()
+        w.append("ld\n")
+        assert w.can_commit()
+        assert w.render_committed() == "world\n"
+
+    def test_row_count_basic(self):
+        w = PlainTextWriter()
+        assert w.row_count("hello", 80) == 1
+        assert w.row_count("", 80) == 0
+
+    def test_row_count_wrapping(self):
+        w = PlainTextWriter()
+        assert w.row_count("a" * 100, 80) == 2
+
+    def test_row_count_cjk(self):
+        w = PlainTextWriter()
+        assert w.row_count("你好世界", 80) == 1  # 8 display cols
+        assert w.row_count("你" * 40, 80) == 1  # 80 display cols
+        assert w.row_count("你" * 41, 80) == 2  # 82 → wraps
+
+    def test_reset(self):
+        w = PlainTextWriter()
+        w.append("hello\n")
+        w.reset()
+        assert not w.has_content()
+        assert not w.can_commit()
+
+    def test_protocol_compliance(self):
+        assert isinstance(PlainTextWriter(), StreamWriter)
+
+
+class TestMarkdownWriter:
+    def test_single_paragraph_is_commits(self):
+        w = MarkdownWriter()
+        w.append("Hello world")
+        # No unclosed fences → single paragraph is committable
+        assert w.can_commit()
+        assert "Hello world" in w.render_committed().markup
+
+    def test_two_paragraphs_commits_first(self):
+        w = MarkdownWriter()
+        w.append("First paragraph\n\nSecond paragraph")
+        assert w.can_commit()
+        committed = w.render_committed()
+        assert "First paragraph" in committed.markup
+
+    def test_unclosed_fence_keeps_partial(self):
+        w = MarkdownWriter()
+        w.append("Text\n\n```python\ncode here")
+        assert w.can_commit()
+        assert "Text" in w.render_committed().markup
+
+    def test_closed_fence_commits_all(self):
+        w = MarkdownWriter()
+        w.append("Text\n\n```python\ncode here\n```")
+        assert w.can_commit()
+
+    def test_commit_clears_committed(self):
+        w = MarkdownWriter()
+        w.append("Block one\n\nBlock two")
+        w.commit()
+        assert not w.can_commit() or w.has_content()
+
+    def test_flush_renders_everything(self):
+        w = MarkdownWriter()
+        w.append("Partial content")
+        result = w.flush()
+        assert result is not None
+        assert not w.has_content()
+
+    def test_flush_returns_none_when_empty(self):
+        w = MarkdownWriter()
+        assert w.flush() is None
+
+    def test_streaming_code_block(self):
+        w = MarkdownWriter()
+        w.append("Here is code:\n\n")
+        assert w.can_commit()
+        w.commit()
+        w.append("```python\n")
+        assert not w.can_commit()
+        w.append("def hello():\n    pass\n")
+        assert not w.can_commit()
+        w.append("```\n\nDone!")
+        assert w.can_commit()
+
+    def test_reset(self):
+        w = MarkdownWriter()
+        w.append("hello\n\nworld")
+        w.reset()
+        assert not w.has_content()
+        assert not w.can_commit()
+
+    def test_protocol_compliance(self):
+        assert isinstance(MarkdownWriter(), StreamWriter)
+
+    def test_row_count_empty(self):
+        w = MarkdownWriter()
+        from rich.text import Text
+
+        assert w.row_count(Text(""), 80) == 0
+
+
+class TestTrimPartialClosingFences:
+    def test_strips_unclosed_fence(self):
+        text = "```python\ncode\n```"
+        result = _trim_partial_closing_fences(text)
+        assert result.count("```") % 2 == 0
+
+    def test_preserves_paired_fences(self):
+        text = "```python\ncode\n```\n\n```bash\nmore"
+        result = _trim_partial_closing_fences(text)
+        assert result.count("```") == 2
+
+    def test_no_fences_unchanged(self):
+        text = "Just plain text"
+        assert _trim_partial_closing_fences(text) == text
+
+    def test_empty_string(self):
+        assert _trim_partial_closing_fences("") == ""
+
+    def test_single_open_fence(self):
+        text = "```python\ndef hello():"
+        result = _trim_partial_closing_fences(text)
+        assert "```" not in result

--- a/tests/test_terminal_output.py
+++ b/tests/test_terminal_output.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from io import StringIO
+
+from prompt_toolkit.data_structures import Size
+
+from bub.channels.cli.terminal_output import SynchronizedVt100Output, create_synchronized_output
+
+_BEGIN_SYNCHRONIZED_UPDATE = "\x1b[?2026h"
+_END_SYNCHRONIZED_UPDATE = "\x1b[?2026l"
+
+
+def _output(stream: StringIO) -> SynchronizedVt100Output:
+    return SynchronizedVt100Output(
+        stream,
+        lambda: Size(rows=24, columns=80),
+        term="xterm-256color",
+        enable_cpr=False,
+    )
+
+
+def test_synchronized_output_flushes_one_atomic_frame() -> None:
+    stream = StringIO()
+    output = _output(stream)
+
+    output.write_raw("\x1b[?25lpaint\x1b[?25h")
+    output.flush()
+
+    assert stream.getvalue() == (
+        f"{_BEGIN_SYNCHRONIZED_UPDATE}\x1b[?25lpaint\x1b[?25h{_END_SYNCHRONIZED_UPDATE}"
+    )
+
+
+def test_synchronized_update_groups_multiple_flushes() -> None:
+    stream = StringIO()
+    output = _output(stream)
+
+    with output.synchronized_update():
+        output.write_raw("erase prompt")
+        output.flush()
+        with output.synchronized_update():
+            output.write_raw("print committed block")
+            output.flush()
+        output.write_raw("restore prompt")
+        output.flush()
+
+    assert stream.getvalue() == (
+        f"{_BEGIN_SYNCHRONIZED_UPDATE}"
+        "erase promptprint committed blockrestore prompt"
+        f"{_END_SYNCHRONIZED_UPDATE}"
+    )
+
+
+def test_create_synchronized_output_keeps_non_tty_default() -> None:
+    assert create_synchronized_output(StringIO()) is None
+
+
+def test_create_synchronized_output_keeps_windows_default(monkeypatch) -> None:
+    class TtyStringIO(StringIO):
+        def isatty(self) -> bool:
+            return True
+
+    monkeypatch.setattr("bub.channels.cli.terminal_output.sys.platform", "win32")
+
+    assert create_synchronized_output(TtyStringIO()) is None


### PR DESCRIPTION
## Summary

- Render partial Markdown through prompt_toolkit so tables, emphasis, links, and fenced code update in real time.
- Synchronize terminal frames and toolbar restoration to eliminate bottom-toolbar flicker.
- Preserve syntax highlighting without a forced black code background, and keep fenced blocks intact across internal blank lines.
- Retain prompt_toolkit platform output on Windows.

## Verification

- uv run pytest -q: 289 passed
- uv run ruff check .: passed
- uv run mypy src: passed
- uv run bub --help: passed
- git diff --check: passed