### PR TITLE
fix(codex): forward output token limit

### DIFF
--- a/src/bub/builtin/codex_provider.py
+++ b/src/bub/builtin/codex_provider.py
@@ -136,6 +136,9 @@ class OpenaiCodexProvider(BaseOpenAIProvider):
             response_format=params.response_format,
             stream=params.stream,
             parallel_tool_calls=params.parallel_tool_calls,
+            max_output_tokens=(
+                params.max_completion_tokens if params.max_completion_tokens is not None else params.max_tokens
+            ),
             reasoning=reasoning,
         )
 

--- a/tests/test_builtin_codex.py
+++ b/tests/test_builtin_codex.py
@@ -189,8 +189,23 @@ def test_codex_completion_params_use_official_responses_payload_fields() -> None
     assert payload == {
         "model": "gpt-5.5",
         "input": [{"role": "user", "content": "hello"}],
+        "max_output_tokens": 100,
         "stream": True,
     }
+
+
+def test_codex_completion_params_prefer_max_completion_tokens() -> None:
+    provider = OpenaiCodexProvider(api_key=_jwt_with_account("acct_123"))
+    params = CompletionParams(
+        model_id="gpt-5.5",
+        messages=[{"role": "user", "content": "hello"}],
+        max_tokens=100,
+        max_completion_tokens=200,
+    )
+
+    responses_params = provider._completion_params_to_responses_params(params)
+
+    assert responses_params.max_output_tokens == 200
 
 
 def test_codex_completion_params_convert_chat_tool_messages_to_responses_items() -> None:


### PR DESCRIPTION
## Rationale

Bub passes its configured `max_tokens` through any-llm's Chat Completions interface. The Codex OAuth provider translates that request to the Responses API, but previously omitted the corresponding `max_output_tokens` field. As a result, output token limits worked with other APIs but were silently ignored for Codex OAuth requests.

## Summary

- map `max_completion_tokens`, or `max_tokens` as a fallback, to Responses `max_output_tokens`
- preserve `max_completion_tokens` precedence when both values are provided
- add regression coverage for the translated payload and precedence behavior

## User-facing changes

Configured output token limits now apply to Codex OAuth completions. There are no API or configuration changes.

## Breaking changes

None.

## Validation

- `uv lock --locked`
- `uv run prek run -a`
- `uv run mypy src`
- `uv run python -m pytest --doctest-modules -q` (`269 passed`)
