### PR TITLE
fix(agent): remove default step limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Lines starting with `,` enter internal command mode (`,help`, `,skill name=my-sk
 | `BUB_API_BASE`              | —                            | Custom provider endpoint                             |
 | `BUB_CLIENT_ARGS`           | —                            | JSON object forwarded to the underlying model client |
 | `BUB_COMPLETION_ARGS`       | —                            | JSON object forwarded to each completion call         |
-| `BUB_MAX_STEPS`             | `50`                         | Max tool-use loop iterations                         |
+| `BUB_MAX_STEPS`             | unlimited                    | Tool-use loop limit; must be a positive integer      |
 | `BUB_MAX_TOKENS`            | `16384`                      | Max tokens per model call                            |
 | `BUB_MODEL_TIMEOUT_SECONDS` | —                            | Model call timeout (seconds)                         |
 

--- a/src/bub/builtin/settings.py
+++ b/src/bub/builtin/settings.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import pathlib
 import re
+import sys
 from dataclasses import dataclass
 from typing import Any
 
@@ -56,7 +57,7 @@ class AgentSettings(Settings):
     fallback_models: list[str] | None = None
     api_key: str | dict[str, str] | None = None
     api_base: str | dict[str, str] | None = None
-    max_steps: int = 50
+    max_steps: int = Field(default=sys.maxsize, gt=0)
     max_tokens: int = DEFAULT_MAX_TOKENS
     model_timeout_seconds: int | None = None
     client_args: dict[str, Any] = Field(default_factory=dict)

--- a/website/src/content/docs/docs/reference/settings.mdx
+++ b/website/src/content/docs/docs/reference/settings.mdx
@@ -44,7 +44,7 @@ class AgentSettings(Settings):
     fallback_models: list[str] | None = None
     api_key: str | dict[str, str] | None = None
     api_base: str | dict[str, str] | None = None
-    max_steps: int = 50
+    max_steps: int = Field(default=sys.maxsize, gt=0)
     max_tokens: int = DEFAULT_MAX_TOKENS  # 16384
     model_timeout_seconds: int | None = None
     client_args: dict[str, Any] = Field(default_factory=dict)
@@ -62,7 +62,7 @@ Loaded under the YAML root section.
 | `BUB_API_BASE` | unset | `api_base` | Default API base URL or per-provider mapping. |
 | `BUB_<PROVIDER>_API_KEY` | unset | — | Provider-scoped API key, e.g. `BUB_OPENAI_API_KEY`. |
 | `BUB_<PROVIDER>_API_BASE` | unset | — | Provider-scoped API base URL, e.g. `BUB_OPENROUTER_API_BASE`. |
-| `BUB_MAX_STEPS` | `50` | `max_steps` | Maximum agent loop iterations per turn. |
+| `BUB_MAX_STEPS` | unlimited | `max_steps` | Maximum agent loop iterations per turn. Must be a positive integer when set. |
 | `BUB_MAX_TOKENS` | `16384` | `max_tokens` | Maximum tokens per model call. |
 | `BUB_MODEL_TIMEOUT_SECONDS` | `null` | `model_timeout_seconds` | Per-call timeout in seconds. |
 | `BUB_CLIENT_ARGS` | `{}` | `client_args` | Extra kwargs passed to the underlying model client (JSON / dict). |

--- a/website/src/content/docs/zh-cn/docs/reference/settings.mdx
+++ b/website/src/content/docs/zh-cn/docs/reference/settings.mdx
@@ -44,7 +44,7 @@ class AgentSettings(Settings):
     fallback_models: list[str] | None = None
     api_key: str | dict[str, str] | None = None
     api_base: str | dict[str, str] | None = None
-    max_steps: int = 50
+    max_steps: int = Field(default=sys.maxsize, gt=0)
     max_tokens: int = DEFAULT_MAX_TOKENS  # 16384
     model_timeout_seconds: int | None = None
     client_args: dict[str, Any] = Field(default_factory=dict)
@@ -62,7 +62,7 @@ class AgentSettings(Settings):
 | `BUB_API_BASE` | unset | `api_base` | 默认 API base URL,或按 provider 索引的映射。 |
 | `BUB_<PROVIDER>_API_KEY` | unset | — | 按 provider 划分的 API key,例如 `BUB_OPENAI_API_KEY`。 |
 | `BUB_<PROVIDER>_API_BASE` | unset | — | 按 provider 划分的 API base URL,例如 `BUB_OPENROUTER_API_BASE`。 |
-| `BUB_MAX_STEPS` | `50` | `max_steps` | 单次 turn 内 agent 循环的最大步数。 |
+| `BUB_MAX_STEPS` | 不限制 | `max_steps` | 单次 turn 内 agent 循环的最大步数；配置时必须为正整数。 |
 | `BUB_MAX_TOKENS` | `16384` | `max_tokens` | 单次模型调用的最大 token 数。 |
 | `BUB_MODEL_TIMEOUT_SECONDS` | `null` | `model_timeout_seconds` | 单次调用的超时秒数。 |
 | `BUB_CLIENT_ARGS` | `{}` | `client_args` | 传递给底层模型 client 的额外 kwargs(JSON / dict)。 |


### PR DESCRIPTION
## Summary

Set `AgentSettings.max_steps` to an effectively unlimited default while requiring configured values to be positive. Update the related settings documentation.

## Testing

- `uv run pytest -q` (274 passed)
- `uv run mypy src`
- `uv run ruff check .`