### PR TITLE
feat(builtin): add named orcarouter provider

### DIFF
--- a/env.example
+++ b/env.example
@@ -18,6 +18,9 @@
 # `AgentSettings` reads `BUB_API_KEY` and `BUB_API_BASE` directly.
 # Provider-specific keys such as `OPENROUTER_API_KEY` may still be used by
 # the underlying SDK/provider setup, but are not read by Bub settings itself.
+# Per-provider `BUB_<PROVIDER>_API_KEY` / `BUB_<PROVIDER>_API_BASE` variables
+# (e.g. `BUB_ORCAROUTER_API_KEY`) are read by Bub settings and scoped to that
+# provider's model prefix.
 
 # Preferred explicit key
 # BUB_API_KEY=sk-...
@@ -67,4 +70,14 @@
 # ---------------------------------------------------------------------------
 # BUB_MODEL=openrouter:openrouter/free
 # BUB_API_KEY=sk-or-...
+# BUB_CLIENT_ARGS={"extra_headers":{"HTTP-Referer":"https://openclaw.ai","X-Title":"OpenClaw"}}
+
+# ---------------------------------------------------------------------------
+# Example OrcaRouter setup
+# ---------------------------------------------------------------------------
+# OrcaRouter is an OpenAI-compatible gateway (https://www.orcarouter.ai) with a
+# unified `/v1` endpoint and gateway-level, zero-trust security for AI agents.
+# Use the `orcarouter:` model prefix and an `sk-orca-...` key.
+# BUB_MODEL=orcarouter:orcarouter/auto
+# BUB_ORCAROUTER_API_KEY=sk-orca-...
 # BUB_CLIENT_ARGS={"extra_headers":{"HTTP-Referer":"https://openclaw.ai","X-Title":"OpenClaw"}}

--- a/src/bub/builtin/hook_impl.py
+++ b/src/bub/builtin/hook_impl.py
@@ -28,6 +28,7 @@ from bub.turn import TurnState
 AGENTS_FILE_NAME = "AGENTS.md"
 MODEL_PROVIDER_CHOICES: tuple[str, ...] = (
     "openrouter",
+    "orcarouter",
     "openai",
     "anthropic",
     "gemini",

--- a/src/bub/builtin/model_runner.py
+++ b/src/bub/builtin/model_runner.py
@@ -27,6 +27,7 @@ from loguru import logger
 from pydantic import TypeAdapter, ValidationError
 
 from bub.builtin.codex_provider import OpenaiCodexProvider, should_use_openai_codex_provider
+from bub.builtin.orcarouter_provider import ORCAROUTER_PROVIDER, OrcaRouterProvider
 from bub.builtin.settings import AgentSettings, ModelCandidate
 from bub.builtin.tape import Tape
 from bub.errors import BubError, ErrorKind
@@ -71,8 +72,10 @@ class ModelRunner:
 
     @staticmethod
     def create_llm_client(candidate: ModelCandidate, client_kwargs: dict[str, Any]) -> AnyLLM:
+        if candidate.provider == ORCAROUTER_PROVIDER:
+            return OrcaRouterProvider(**client_kwargs)
         if candidate.provider == LLMProvider.OPENAI and should_use_openai_codex_provider(
-            candidate.provider.value,
+            LLMProvider.OPENAI.value,
             candidate.model_id,
             api_key=client_kwargs.get("api_key"),
             api_base=client_kwargs.get("api_base"),

--- a/src/bub/builtin/orcarouter_provider.py
+++ b/src/bub/builtin/orcarouter_provider.py
@@ -1,0 +1,41 @@
+"""OpenAI-compatible OrcaRouter provider for any-llm completions."""
+
+from __future__ import annotations
+
+from any_llm.providers.openai.base import BaseOpenAIProvider
+
+ORCAROUTER_PROVIDER = "orcarouter"
+"""Bub-side provider key for OrcaRouter models.
+
+any-llm-sdk has no named OrcaRouter provider, so Bub resolves the ``orcarouter:``
+model prefix itself (see ``AgentSettings.split_model_provider``) and builds this
+OpenAI-compatible provider for it.
+"""
+
+
+class OrcaRouterProvider(BaseOpenAIProvider):
+    """OpenAI-compatible completions provider backed by the OrcaRouter gateway.
+
+    OrcaRouter exposes a unified OpenAI-compatible endpoint (``/v1``) in front of
+    models from multiple providers, and additionally runs gateway-level,
+    zero-trust security for AI agents on the same endpoint. Model ids are the
+    OrcaRouter-side ids (e.g. ``orcarouter/auto``).
+    """
+
+    API_BASE = "https://api.orcarouter.ai/v1"
+    ENV_API_KEY_NAME = "ORCAROUTER_API_KEY"
+    ENV_API_BASE_NAME = "ORCAROUTER_API_BASE"
+    PROVIDER_NAME = ORCAROUTER_PROVIDER
+    PROVIDER_DOCUMENTATION_URL = "https://www.orcarouter.ai"
+
+    SUPPORTS_COMPLETION_STREAMING = True
+    SUPPORTS_COMPLETION = True
+    SUPPORTS_COMPLETION_REASONING = True
+    SUPPORTS_RESPONSES = False
+    SUPPORTS_LIST_MODELS = True
+    SUPPORTS_BATCH = False
+    SUPPORTS_IMAGE_GENERATION = False
+    SUPPORTS_AUDIO_TRANSCRIPTION = False
+    SUPPORTS_AUDIO_SPEECH = False
+    SUPPORTS_EMBEDDING = True
+    SUPPORTS_MODERATION = False

--- a/src/bub/builtin/settings.py
+++ b/src/bub/builtin/settings.py
@@ -14,6 +14,7 @@ from pydantic.fields import FieldInfo
 from pydantic_settings import BaseSettings, PydanticBaseSettingsSource, SettingsConfigDict
 
 from bub import Settings, config, ensure_config
+from bub.builtin.orcarouter_provider import ORCAROUTER_PROVIDER
 
 DEFAULT_MODEL = "openrouter:openrouter/free"
 DEFAULT_MAX_TOKENS = 16384
@@ -21,7 +22,7 @@ DEFAULT_MAX_TOKENS = 16384
 
 @dataclass(frozen=True)
 class ModelCandidate:
-    provider: LLMProvider
+    provider: LLMProvider | str
     model_id: str
     name: str
 
@@ -93,11 +94,24 @@ class AgentSettings(Settings):
 
         candidates: list[ModelCandidate] = []
         for candidate in candidate_names:
-            provider, model_id = AnyLLM.split_model_provider(candidate)
+            provider, model_id = self.split_model_provider(candidate)
             candidates.append(ModelCandidate(provider=provider, model_id=model_id, name=candidate))
         return candidates
 
-    def model_client_kwargs(self, provider: LLMProvider) -> dict[str, Any]:
+    @staticmethod
+    def split_model_provider(model: str) -> tuple[LLMProvider | str, str]:
+        """Split ``provider:model_id``, resolving the OrcaRouter prefix locally.
+
+        any-llm-sdk has no named OrcaRouter provider, so ``AnyLLM.split_model_provider``
+        raises for ``orcarouter:...`` models. Bub resolves the prefix itself and lets
+        ``ModelRunner`` build the OpenAI-compatible ``OrcaRouterProvider`` for it.
+        """
+        provider, separator, model_id = model.partition(":")
+        if separator and provider == ORCAROUTER_PROVIDER and model_id:
+            return ORCAROUTER_PROVIDER, model_id
+        return AnyLLM.split_model_provider(model)
+
+    def model_client_kwargs(self, provider: LLMProvider | str) -> dict[str, Any]:
         return {
             **self.client_args,
             "api_key": self._provider_value(self.api_key, provider),
@@ -105,9 +119,10 @@ class AgentSettings(Settings):
         }
 
     @staticmethod
-    def _provider_value(value: str | dict[str, str] | None, provider: LLMProvider) -> str | None:
+    def _provider_value(value: str | dict[str, str] | None, provider: LLMProvider | str) -> str | None:
         if isinstance(value, dict):
-            return value.get(provider.value)
+            key = provider.value if isinstance(provider, LLMProvider) else provider
+            return value.get(key)
         return value
 
     @property

--- a/tests/test_builtin_model_runner.py
+++ b/tests/test_builtin_model_runner.py
@@ -11,6 +11,7 @@ from any_llm.providers.openai.base import BaseOpenAIProvider
 from any_llm.types.completion import ChatCompletionChunk, ChatCompletionMessageFunctionToolCall, Function
 
 from bub.builtin.model_runner import ModelRunner, tool_invocation_from_native
+from bub.builtin.orcarouter_provider import OrcaRouterProvider
 from bub.builtin.settings import AgentSettings, ModelCandidate
 from bub.builtin.tape import Tape
 from bub.tape import AsyncTapeStoreAdapter, InMemoryTapeStore, TapeContext
@@ -30,6 +31,20 @@ async def test_unknown_tool_placeholder_surfaces_error_without_hooks() -> None:
 
     assert execution.error is not None
     assert "missing_tool" in execution.error.message
+
+
+def test_create_llm_client_returns_orcarouter_provider() -> None:
+    candidate = ModelCandidate(provider="orcarouter", model_id="orcarouter/auto", name="orcarouter:orcarouter/auto")
+
+    client = ModelRunner.create_llm_client(
+        candidate,
+        {"api_key": "sk-orca-test", "api_base": "https://api.orcarouter.ai/v1"},
+    )
+
+    assert isinstance(client, OrcaRouterProvider)
+    assert client.PROVIDER_NAME == "orcarouter"
+    assert client.API_BASE == "https://api.orcarouter.ai/v1"
+    assert client.SUPPORTS_COMPLETION_STREAMING is True
 
 
 class _FakeStreamingOpenAIProvider(BaseOpenAIProvider):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -48,6 +48,29 @@ def test_settings_provider_names_are_lowercased() -> None:
     assert "openrouter" in settings.api_key
 
 
+def test_settings_orcarouter_model_prefix_resolves_to_named_provider() -> None:
+    settings = _settings_with_env({"BUB_ORCAROUTER_API_KEY": "sk-orca-test"})
+
+    candidates = settings.model_candidates("orcarouter:orcarouter/auto")
+
+    assert len(candidates) == 1
+    assert candidates[0].provider == "orcarouter"
+    assert candidates[0].model_id == "orcarouter/auto"
+    assert candidates[0].name == "orcarouter:orcarouter/auto"
+
+
+def test_settings_orcarouter_per_provider_key_and_base() -> None:
+    settings = _settings_with_env({
+        "BUB_ORCAROUTER_API_KEY": "sk-orca-test",
+        "BUB_ORCAROUTER_API_BASE": "https://api.orcarouter.ai/v1",
+    })
+
+    kwargs = settings.model_client_kwargs("orcarouter")
+
+    assert kwargs["api_key"] == "sk-orca-test"
+    assert kwargs["api_base"] == "https://api.orcarouter.ai/v1"
+
+
 def test_settings_mixed_single_key_with_per_provider_base() -> None:
     settings = _settings_with_env({
         "BUB_API_KEY": "sk-global",

--- a/website/src/content/docs/docs/operate/configure.mdx
+++ b/website/src/content/docs/docs/operate/configure.mdx
@@ -47,6 +47,15 @@ telegram:
   allow_users: "123456789,your_username"
 ```
 
+Or use the builtin `orcarouter` provider for the [OrcaRouter](https://www.orcarouter.ai) gateway (an OpenAI-compatible endpoint with gateway-level, zero-trust security for AI agents), scoping the key to the provider:
+
+```yaml
+# ~/.bub/config.yml
+model: orcarouter:orcarouter/auto
+api_key:
+  orcarouter: sk-orca-...
+```
+
 Top-level keys map to `AgentSettings` in [src/bub/builtin/settings.py](https://github.com/bubbuild/bub/blob/main/src/bub/builtin/settings.py). Per-channel keys (such as `telegram:`) map to that channel's `Settings` subclass.
 
 ## 3. Override at runtime with environment variables
@@ -59,7 +68,7 @@ Every YAML key has a matching environment variable. The pattern is `BUB_<UPPERCA
 | `BUB_API_KEY` | API key for the active provider. Leave unset when using `bub login openai`. |
 | `BUB_API_BASE` | Override the provider's base URL. Leave unset for Codex OAuth so Bub can route through the Codex backend. |
 | `BUB_HOME` | Bub's runtime data directory (history, tapes, managed plugin project). Default `~/.bub`; does not move the default config file. |
-| `BUB_<PROVIDER>_API_KEY` | Per-provider key, e.g. `BUB_OPENROUTER_API_KEY`. |
+| `BUB_<PROVIDER>_API_KEY` | Per-provider key, e.g. `BUB_OPENROUTER_API_KEY` or `BUB_ORCAROUTER_API_KEY`. |
 | `BUB_<PROVIDER>_API_BASE` | Per-provider base URL. |
 
 When you use `uv run bub login openai`, Bub reads Codex OAuth credentials from `CODEX_HOME` or `~/.codex` and refreshes them automatically. Use a model id under the `openai:` provider and keep both `BUB_API_KEY` and `BUB_API_BASE` unset for that path.

--- a/website/src/content/docs/docs/reference/settings.mdx
+++ b/website/src/content/docs/docs/reference/settings.mdx
@@ -60,7 +60,7 @@ Loaded under the YAML root section.
 | `BUB_FALLBACK_MODELS` | `null` | `fallback_models` | Optional list of fallback model identifiers. |
 | `BUB_API_KEY` | unset | `api_key` | Default API key. May also be a JSON object mapping provider → key. |
 | `BUB_API_BASE` | unset | `api_base` | Default API base URL or per-provider mapping. |
-| `BUB_<PROVIDER>_API_KEY` | unset | — | Provider-scoped API key, e.g. `BUB_OPENAI_API_KEY`. |
+| `BUB_<PROVIDER>_API_KEY` | unset | — | Provider-scoped API key, e.g. `BUB_OPENAI_API_KEY` or `BUB_ORCAROUTER_API_KEY`. |
 | `BUB_<PROVIDER>_API_BASE` | unset | — | Provider-scoped API base URL, e.g. `BUB_OPENROUTER_API_BASE`. |
 | `BUB_MAX_STEPS` | unlimited | `max_steps` | Maximum agent loop iterations per turn. Must be a positive integer when set. |
 | `BUB_MAX_TOKENS` | `16384` | `max_tokens` | Maximum tokens per model call. |
@@ -70,6 +70,8 @@ Loaded under the YAML root section.
 | `BUB_VERBOSE` | `0` | `verbose` | Logging verbosity level (`0`–`2`). |
 
 Provider-specific defaults are gathered at startup by scanning `os.environ` for `^BUB_(.+)_(API_KEY|API_BASE)$` and lowercasing the captured provider name.
+
+In addition to the providers any-llm-sdk knows natively, Bub has a named `orcarouter` provider for the [OrcaRouter](https://www.orcarouter.ai) gateway: a unified OpenAI-compatible endpoint in front of models from multiple providers, with keys prefixed `sk-orca-`. Set the model as `orcarouter:<model-id>` (e.g. `orcarouter:orcarouter/auto`) and, optionally, scope a key via `BUB_ORCAROUTER_API_KEY`.
 
 OpenAI Codex OAuth does not need a separate request-format setting. After `bub login openai`, Bub detects the stored Codex OAuth token when the selected model uses the `openai:` provider and no custom API base is set.
 

--- a/website/src/content/docs/zh-cn/docs/operate/configure.mdx
+++ b/website/src/content/docs/zh-cn/docs/operate/configure.mdx
@@ -47,6 +47,15 @@ telegram:
   allow_users: "123456789,your_username"
 ```
 
+也可以使用内置的 `orcarouter` provider 连接 [OrcaRouter](https://www.orcarouter.ai) 网关（提供 OpenAI 兼容端点，并在同一端点对 AI agent 执行 gateway 级零信任安全防护），把 key 限定到该 provider：
+
+```yaml
+# ~/.bub/config.yml
+model: orcarouter:orcarouter/auto
+api_key:
+  orcarouter: sk-orca-...
+```
+
 顶层键对应 [src/bub/builtin/settings.py](https://github.com/bubbuild/bub/blob/main/src/bub/builtin/settings.py) 中的 `AgentSettings`。每个 channel 的子键（如 `telegram:`）对应该 channel 的 `Settings` 子类。
 
 ## 3. 用环境变量在运行时覆盖
@@ -59,7 +68,7 @@ telegram:
 | `BUB_API_KEY` | 当前提供商的 API key。使用 `bub login openai` 时保持未设置。 |
 | `BUB_API_BASE` | 覆盖提供商的基础 URL。使用 Codex OAuth 时保持未设置，以便 Bub 路由到 Codex backend。 |
 | `BUB_HOME` | Bub 的运行时数据目录（history、tapes、托管插件项目）。默认 `~/.bub`；不会移动默认配置文件。 |
-| `BUB_<PROVIDER>_API_KEY` | 单个提供商的 key，如 `BUB_OPENROUTER_API_KEY`。 |
+| `BUB_<PROVIDER>_API_KEY` | 单个提供商的 key，如 `BUB_OPENROUTER_API_KEY` 或 `BUB_ORCAROUTER_API_KEY`。 |
 | `BUB_<PROVIDER>_API_BASE` | 单个提供商的基础 URL。 |
 
 使用 `uv run bub login openai` 时，Bub 会从 `CODEX_HOME` 或 `~/.codex` 读取 Codex OAuth 凭据，并自动 refresh。这个路径下使用 `openai:` provider 的模型标识，同时保持 `BUB_API_KEY` 和 `BUB_API_BASE` 未设置。

--- a/website/src/content/docs/zh-cn/docs/reference/settings.mdx
+++ b/website/src/content/docs/zh-cn/docs/reference/settings.mdx
@@ -60,7 +60,7 @@ class AgentSettings(Settings):
 | `BUB_FALLBACK_MODELS` | `null` | `fallback_models` | 可选的回退模型标识列表。 |
 | `BUB_API_KEY` | unset | `api_key` | 默认 API key;也可以是按 provider 索引的 JSON object。 |
 | `BUB_API_BASE` | unset | `api_base` | 默认 API base URL,或按 provider 索引的映射。 |
-| `BUB_<PROVIDER>_API_KEY` | unset | — | 按 provider 划分的 API key,例如 `BUB_OPENAI_API_KEY`。 |
+| `BUB_<PROVIDER>_API_KEY` | unset | — | 按 provider 划分的 API key,例如 `BUB_OPENAI_API_KEY` 或 `BUB_ORCAROUTER_API_KEY`。 |
 | `BUB_<PROVIDER>_API_BASE` | unset | — | 按 provider 划分的 API base URL,例如 `BUB_OPENROUTER_API_BASE`。 |
 | `BUB_MAX_STEPS` | 不限制 | `max_steps` | 单次 turn 内 agent 循环的最大步数；配置时必须为正整数。 |
 | `BUB_MAX_TOKENS` | `16384` | `max_tokens` | 单次模型调用的最大 token 数。 |
@@ -70,6 +70,8 @@ class AgentSettings(Settings):
 | `BUB_VERBOSE` | `0` | `verbose` | 日志详细级别(`0`–`2`)。 |
 
 启动时 `ProviderSpecificEnvSource` 会扫描 `os.environ` 中匹配 `^BUB_(.+)_(API_KEY|API_BASE)$` 的变量,把捕获到的 provider 名称小写后作为 key 收集。
+
+除 any-llm-sdk 原生支持的 provider 外,Bub 还内置了一个名为 `orcarouter` 的 provider,用于接入 [OrcaRouter](https://www.orcarouter.ai) 网关:一个统一的 OpenAI 兼容端点,key 前缀为 `sk-orca-`。模型标识写成 `orcarouter:<model-id>`(例如 `orcarouter:orcarouter/auto`),并可通过 `BUB_ORCAROUTER_API_KEY` 为该 provider 单独设置 key。
 
 OpenAI Codex OAuth 不需要单独的请求格式设置。运行 `bub login openai` 后,当模型使用 `openai:` provider 且没有自定义 API base 时,Bub 会检测并使用本地保存的 Codex OAuth token。
 


### PR DESCRIPTION
## Summary

Adds **[OrcaRouter](https://www.orcarouter.ai)** as a named model provider, mirroring how this repo wires OpenRouter. OrcaRouter is an OpenAI-compatible model routing gateway that exposes models from OpenAI, Anthropic, Google, DeepSeek and others behind a single endpoint and API key. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

I'm an engineer on the OrcaRouter team.

## What this changes

- `src/bub/builtin/orcarouter_provider.py` (new): `OrcaRouterProvider`, an OpenAI-compatible provider backed by `https://api.orcarouter.ai/v1`, with `ORCAROUTER_API_KEY` / `ORCAROUTER_API_BASE` env vars, mirroring `OpenrouterProvider`.
- `src/bub/builtin/settings.py`: `AgentSettings.split_model_provider` resolves the `orcarouter:` model prefix locally, since any-llm-sdk has no named OrcaRouter provider; `model_client_kwargs` handles the string provider key for per-provider `BUB_ORCAROUTER_API_KEY` / `BUB_ORCAROUTER_API_BASE`.
- `src/bub/builtin/model_runner.py`: `create_llm_client` builds `OrcaRouterProvider` for `orcarouter` candidates.
- `src/bub/builtin/hook_impl.py`: adds `orcarouter` to `MODEL_PROVIDER_CHOICES` so it appears in the onboarding provider picker.
- `tests/test_settings.py`, `tests/test_builtin_model_runner.py`: unit tests for prefix resolution, per-provider key lookup, and client construction.
- `env.example` + website docs (`configure.mdx`, `reference/settings.mdx`, en + zh-cn): named OrcaRouter config blocks alongside the OpenRouter examples.

## Why a separate provider rather than the OpenAI-compatible escape hatch

This mirrors how OpenRouter is wired in this repo, so the model picker, docs and config reference stay consistent for users. OrcaRouter also ships gateway-level security controls for AI agents, so using it through Bub inherits that protection without application code changes.

## How to use it

1. Get an API key at https://www.orcarouter.ai (keys start with `sk-orca-`).
2. Set `BUB_ORCAROUTER_API_KEY` (or `ORCAROUTER_API_KEY`).
3. Set the model to `orcarouter:<model-id>`, for example:

```bash
BUB_MODEL=orcarouter:orcarouter/auto
```

## Verification

- `uv run ruff check .` - all checks passed.
- `uv run mypy src` - no issues found in 48 source files.
- `uv run pytest -q` - 208 passed; the 13 failures are pre-existing Windows-only failures (`test_builtin_cli.py`, `test_builtin_tools.py`, `test_builtin_codex.py`) that fail identically on `main` in this environment.
- Live API: exercised the new `OrcaRouterProvider` against `https://api.orcarouter.ai/v1` with a real key (`orcarouter/auto`, non-streaming completion) - HTTP 200 with an expected response.
