### PR TITLE
feat(cli): refine streamed output rendering

### DIFF
--- a/src/bub/channels/cli/__init__.py
+++ b/src/bub/channels/cli/__init__.py
@@ -54,10 +54,12 @@ class _StreamPrinter:
         expand_thinking: bool,
         presenter: TerminalPresenter,
         writer: MarkdownWriter | None = None,
+        print_end: Callable[[], None] | None = None,
         invalidate: Callable[[], None] | None = None,
     ) -> None:
         self._console = console
         self._print_head = print_head
+        self._print_end = print_end or (lambda: None)
         self._expand_thinking = expand_thinking
         self._presenter = presenter
         self._reasoning_chars = 0
@@ -82,13 +84,10 @@ class _StreamPrinter:
 
     async def _record_reasoning(self, reasoning: str) -> None:
         if not self._expand_thinking:
-            if self._reasoning_chars == 0:
-                await self._ensure_head()
             self._reasoning_chars += len(reasoning)
             self._invalidate()
             return
 
-        await self._ensure_head()
         if not self._reasoning_streaming:
             await self._print(Text("[-] Thinking", style="dim"))
             self._reasoning_streaming = True
@@ -97,19 +96,21 @@ class _StreamPrinter:
     async def _print_content(self, content: str) -> bool:
         if not (content.strip() or self.head_printed or self._reasoning_chars or self._reasoning_streaming):
             return False
-        await self._ensure_head()
         await self._close_reasoning_stream()
         await self._flush_reasoning()
+        if content.strip() or self.head_printed:
+            await self._ensure_head()
         await self._write_text(content)
         return True
 
     async def finish(self) -> None:
         await self._close_reasoning_stream()
-        if self._reasoning_chars:
-            await self._ensure_head()
         await self._flush_reasoning()
         if self._writer.has_content():
+            await self._ensure_head()
             await self._flush_text()
+        else:
+            await self._ensure_panel_end()
 
     async def _print_stream_boundary(self) -> None:
         await self.finish()
@@ -121,6 +122,12 @@ class _StreamPrinter:
             return
         await self._presenter.write(self._print_head)
         self.head_printed = True
+
+    async def _ensure_panel_end(self) -> None:
+        if not self.head_printed:
+            return
+        await self._presenter.write(self._print_end)
+        self.head_printed = False
 
     async def _close_reasoning_stream(self) -> None:
         if not self._reasoning_streaming:
@@ -163,6 +170,8 @@ class _StreamPrinter:
         def commit() -> None:
             self._console.print(finished)
             self._writer.clear()
+            self._print_end()
+            self.head_printed = False
 
         await self._presenter.write(commit)
         self._ansi_cache = None
@@ -353,6 +362,7 @@ class CliChannel(Interface):
         printer = _StreamPrinter(
             console=console,
             print_head=lambda: self._renderer.print_head(message.kind),
+            print_end=lambda: self._renderer.print_end(message.kind),
             expand_thinking=self._expand_thinking,
             presenter=self._presenter,
             invalidate=self._invalidate_prompt,

--- a/src/bub/channels/cli/renderer.py
+++ b/src/bub/channels/cli/renderer.py
@@ -10,6 +10,7 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.text import Text
 
+from bub.channels.cli.writers import PanelEnd, PanelHead
 from bub.channels.message import MessageKind
 
 MAX_TOOL_PAYLOAD_CHARS = 4000
@@ -37,20 +38,10 @@ class CliRenderer:
             return
         self.console.print(Text(text, style="bright_black"))
 
-    def command_output(self, text: str) -> None:
-        if not text.strip():
-            return
-        self.console.print(f"[cyan bold]Command >[/]\n{text}")
-
-    def assistant_output(self, text: str) -> None:
-        if not text.strip():
-            return
-        self.console.print(f"[blue bold]Assistant >[/]\n{text}")
-
     def error(self, text: str) -> None:
         if not text.strip():
             return
-        self.console.print(f"[red bold]Error >[/]\n{text}")
+        self.console.print(Panel(text, title="error", border_style="red"))
 
     def input_echo(self, prompt: str, text: str, steering: bool = False) -> None:
         if not text.strip():
@@ -62,8 +53,7 @@ class CliRenderer:
         self.console.print(Text(_format_tool_call(name, args, kwargs), style="magenta"), new_line_start=True)
 
     def tool_call_success(self, *, name: str, result: Any, elapsed_ms: float) -> None:
-        rendered = _format_tool_payload(result)
-        self._tool_result(f"completed in {elapsed_ms:.0f} ms", rendered, style="green")
+        self._tool_status(f"completed in {elapsed_ms:.0f} ms", style="green")
 
     def tool_call_error(self, *, name: str, error: BaseException, elapsed_ms: float) -> None:
         rendered = _format_tool_payload({"type": error.__class__.__name__, "message": str(error)})
@@ -71,11 +61,19 @@ class CliRenderer:
 
     def print_head(self, kind: MessageKind) -> None:
         if kind == "command":
-            self.console.print("[cyan bold]Command >[/]", new_line_start=True)
+            self.console.print(PanelHead("Command", border_style="cyan"))
         elif kind == "error":
-            self.console.print("[red bold]Error >[/]", new_line_start=True)
+            self.console.print(PanelHead("Error", border_style="red"))
         else:
-            self.console.print("[blue bold]Assistant >[/]", new_line_start=True)
+            self.console.print(PanelHead("Assistant", border_style="blue"))
+
+    def print_end(self, kind: MessageKind) -> None:
+        if kind == "command":
+            self.console.print(PanelEnd(border_style="cyan"))
+        elif kind == "error":
+            self.console.print(PanelEnd(border_style="red"))
+        else:
+            self.console.print(PanelEnd(border_style="blue"))
 
     def log(self, message: object) -> None:
         text = str(message).rstrip()
@@ -83,10 +81,12 @@ class CliRenderer:
             self.console.print(text, new_line_start=True)
 
     def _tool_result(self, label: str, rendered: str, *, style: str) -> None:
-        lines = rendered.splitlines() or [""]
-        self.console.print(Text(f"  ⎿ {label}", style=style), highlight=False)
-        for line in lines:
+        self._tool_status(label, style=style)
+        for line in rendered.splitlines() or [""]:
             self.console.print(Text(f"    {line}", style="bright_black"), highlight=False)
+
+    def _tool_status(self, label: str, *, style: str) -> None:
+        self.console.print(Text(f"  ⎿ {label}", style=style), highlight=False)
 
 
 def _format_tool_call(name: str, args: tuple[Any, ...], kwargs: dict[str, Any]) -> str:

--- a/src/bub/channels/cli/writers.py
+++ b/src/bub/channels/cli/writers.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+from rich.console import Console, ConsoleOptions, RenderResult
 from rich.markdown import Markdown
+from rich.panel import Panel
+from rich.segment import Segment
 from rich.text import Text
 
 _MARKDOWN_CODE_THEME = "ansi_dark"
@@ -10,6 +13,37 @@ _MARKDOWN_CODE_THEME = "ansi_dark"
 
 def _markdown(content: str) -> Markdown:
     return Markdown(content, code_theme=_MARKDOWN_CODE_THEME)
+
+
+class PanelHead:
+    """The top border of a Panel, printed before its content is streamed."""
+
+    def __init__(self, title: str, *, border_style: str, width: int | None = None) -> None:
+        self._title = title
+        self._border_style = border_style
+        self._width = width
+
+    def __rich_console__(self, console: Console, options: ConsoleOptions) -> RenderResult:
+        width = self._width if self._width is not None else options.max_width
+        panel = Panel("", title=self._title, border_style=self._border_style, width=width)
+        for line in console.render_lines(panel, options.update(width=width), pad=False)[:1]:
+            yield from line
+        yield Segment.line()
+
+
+class PanelEnd:
+    """The bottom border of a Panel, printed after its content is streamed."""
+
+    def __init__(self, *, border_style: str, width: int | None = None) -> None:
+        self._border_style = border_style
+        self._width = width
+
+    def __rich_console__(self, console: Console, options: ConsoleOptions) -> RenderResult:
+        width = self._width if self._width is not None else options.max_width
+        panel = Panel("", border_style=self._border_style, width=width)
+        for line in console.render_lines(panel, options.update(width=width), pad=False)[-1:]:
+            yield from line
+        yield Segment.line()
 
 
 class MarkdownWriter:

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -1023,7 +1023,7 @@ async def test_cli_channel_stream_events_prints_stream_and_yields_events(monkeyp
     channel = CliChannel.__new__(CliChannel)
     heads: list[str] = []
     printed: list[tuple[str, str | None, bool | None]] = []
-    channel._renderer = SimpleNamespace(print_head=heads.append)
+    channel._renderer = SimpleNamespace(print_head=heads.append, print_end=lambda kind: heads.append(kind + ":end"))
     channel._presenter = _ImmediatePresenter()
     channel._expand_thinking = False
     monkeypatch.setattr(
@@ -1043,7 +1043,7 @@ async def test_cli_channel_stream_events_prints_stream_and_yields_events(monkeyp
 
     yielded = [event async for event in channel.stream_events(message, source())]
 
-    assert heads == ["command"]
+    assert heads == ["command", "command:end"]
     assert len(printed) == 1
     assert getattr(printed[0][0], "markup", None) == "first paragraph\n\nsecond paragraph"
     assert [event.kind for event in yielded] == ["text", "text", "final"]
@@ -1053,7 +1053,7 @@ async def test_cli_channel_stream_events_prints_stream_and_yields_events(monkeyp
 async def test_cli_channel_stream_error_preserves_partial_markdown(monkeypatch: pytest.MonkeyPatch) -> None:
     channel = CliChannel.__new__(CliChannel)
     printed: list[object] = []
-    channel._renderer = SimpleNamespace(print_head=lambda kind: None)
+    channel._renderer = SimpleNamespace(print_head=lambda kind: None, print_end=lambda kind: None)
     channel._presenter = _ImmediatePresenter()
     channel._expand_thinking = False
     monkeypatch.setattr(
@@ -1080,7 +1080,7 @@ async def test_cli_channel_stream_cancellation_preserves_partial_markdown(monkey
     channel = CliChannel.__new__(CliChannel)
     printed: list[object] = []
     partial_received = asyncio.Event()
-    channel._renderer = SimpleNamespace(print_head=lambda kind: None)
+    channel._renderer = SimpleNamespace(print_head=lambda kind: None, print_end=lambda kind: None)
     channel._presenter = _ImmediatePresenter()
     channel._expand_thinking = False
     monkeypatch.setattr(
@@ -1125,7 +1125,7 @@ async def test_cli_channel_final_write_cancellation_retries_partial_markdown(mon
             function()
 
     presenter = CancelFinalWriteOnce()
-    channel._renderer = SimpleNamespace(print_head=lambda kind: None)
+    channel._renderer = SimpleNamespace(print_head=lambda kind: None, print_end=lambda kind: None)
     channel._presenter = presenter
     channel._expand_thinking = False
     monkeypatch.setattr(
@@ -1208,6 +1208,68 @@ async def test_cli_tool_reporter_finishes_before_next_model_output() -> None:
         REGISTRY.pop(tool_name, None)
 
     assert events == ["tool-start", "tool-body", "tool-success", "next-model-text"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("expand_thinking", [False, True])
+async def test_cli_stream_prints_panel_head_after_reasoning_block(expand_thinking: bool) -> None:
+    from rich.text import Text
+    from rich.tree import Tree
+
+    from bub.channels.cli import _StreamPrinter
+
+    events: list[str] = []
+
+    def print_content(content, **kwargs) -> None:
+        if isinstance(content, Text):
+            events.append(content.plain)
+        elif isinstance(content, Tree):
+            events.append("collapsed-thinking")
+        elif content == "":
+            events.append("thinking-end")
+        else:
+            events.append("body")
+
+    printer = _StreamPrinter(
+        console=SimpleNamespace(print=print_content),
+        print_head=lambda: events.append("head"),
+        print_end=lambda: events.append("end"),
+        expand_thinking=expand_thinking,
+        presenter=_ImmediatePresenter(),
+    )
+
+    await printer.render(StreamEvent("reasoning", {"delta": "reasoning"}))
+
+    assert "head" not in events
+
+    await printer.render(StreamEvent("text", {"delta": "answer"}))
+
+    assert events[-1] == "head"
+    assert "reasoning" in events or "collapsed-thinking" in events
+
+    await printer.render(StreamEvent("final", {}))
+
+    assert events[-2:] == ["body", "end"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("expand_thinking", [False, True])
+async def test_cli_reasoning_only_stream_does_not_print_empty_panel(expand_thinking: bool) -> None:
+    from bub.channels.cli import _StreamPrinter
+
+    boundaries: list[str] = []
+    printer = _StreamPrinter(
+        console=SimpleNamespace(print=lambda *args, **kwargs: None),
+        print_head=lambda: boundaries.append("head"),
+        print_end=lambda: boundaries.append("end"),
+        expand_thinking=expand_thinking,
+        presenter=_ImmediatePresenter(),
+    )
+
+    await printer.render(StreamEvent("reasoning", {"delta": "reasoning"}))
+    await printer.render(StreamEvent("final", {}))
+
+    assert boundaries == []
 
 
 @pytest.mark.asyncio
@@ -1406,7 +1468,7 @@ async def test_cli_channel_collapsed_reasoning_does_not_start_status_spinner(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     channel = CliChannel.__new__(CliChannel)
-    channel._renderer = SimpleNamespace(print_head=lambda kind: None)
+    channel._renderer = SimpleNamespace(print_head=lambda kind: None, print_end=lambda kind: None)
     channel._presenter = _ImmediatePresenter()
     channel._expand_thinking = False
     printed: list[object] = []
@@ -1447,24 +1509,46 @@ def test_cli_channel_history_file_uses_workspace_hash(tmp_path: Path) -> None:
 
 
 @pytest.mark.parametrize(
-    ("kind", "expected"),
+    ("kind", "title"),
     [
-        ("command", "[cyan bold]Command >[/]"),
-        ("error", "[red bold]Error >[/]"),
-        ("normal", "[blue bold]Assistant >[/]"),
+        ("command", "Command"),
+        ("error", "Error"),
+        ("normal", "Assistant"),
     ],
 )
-def test_cli_renderer_print_head_uses_message_kind(kind: str, expected: str) -> None:
-    printed: list[tuple[str, bool | None]] = []
+def test_cli_renderer_print_head_uses_message_kind(kind: str, title: str) -> None:
+    from bub.channels.cli.writers import PanelHead
 
-    def print_message(message: str, *, new_line_start: bool | None = None) -> None:
+    printed: list[tuple[object, bool | None]] = []
+
+    def print_message(message: object, *, new_line_start: bool | None = None) -> None:
         printed.append((message, new_line_start))
 
     renderer = CliRenderer(SimpleNamespace(print=print_message))  # type: ignore[arg-type]
 
     renderer.print_head(kind)  # type: ignore[arg-type]
 
-    assert printed == [(expected, True)]
+    assert len(printed) == 1
+    head, new_line_start = printed[0]
+    assert isinstance(head, PanelHead)
+    assert head._title == title
+    assert new_line_start is None
+
+
+def test_cli_renderer_print_end_uses_message_kind() -> None:
+    from bub.channels.cli.writers import PanelEnd
+
+    printed: list[object] = []
+
+    def print_message(message: object, **kwargs: object) -> None:
+        printed.append(message)
+
+    renderer = CliRenderer(SimpleNamespace(print=print_message))  # type: ignore[arg-type]
+
+    renderer.print_end("normal")  # type: ignore[arg-type]
+
+    assert len(printed) == 1
+    assert isinstance(printed[0], PanelEnd)
 
 
 def test_bub_message_filter_accepts_private_messages() -> None:

--- a/tests/test_cli_renderer.py
+++ b/tests/test_cli_renderer.py
@@ -3,20 +3,38 @@ from __future__ import annotations
 from rich.console import Console
 
 from bub.channels.cli.renderer import CliRenderer
+from bub.channels.cli.writers import PanelEnd, PanelHead
 
 
-def test_tool_call_renderer_uses_compact_claude_style_output() -> None:
+def test_panel_head_and_end_commit_separate_terminal_lines() -> None:
+    console = Console(record=True, force_terminal=False, width=40)
+    console.print(PanelHead("assistant", border_style="blue"))
+    console.print("streamed body")
+    console.print(PanelEnd(border_style="blue"))
+    console.print("next prompt")
+
+    lines = console.export_text().splitlines()
+
+    assert len(lines) == 4
+    assert lines[0].startswith("╭")
+    assert "assistant" in lines[0]
+    assert lines[1] == "streamed body"
+    assert lines[2].startswith("╰")
+    assert lines[3] == "next prompt"
+
+
+def test_tool_call_renderer_hides_success_output() -> None:
     console = Console(record=True, force_terminal=False, width=120)
     renderer = CliRenderer(console)
 
     renderer.tool_call_start(name="demo.echo", args=(), kwargs={"value": "hello"})
-    renderer.tool_call_success(name="demo.echo", result={"ok": True}, elapsed_ms=12.3)
+    renderer.tool_call_success(name="demo.echo", result={"secret": "hidden-result"}, elapsed_ms=12.3)
 
     output = console.export_text()
 
     assert '● demo.echo(value: "hello")' in output
     assert "  ⎿ completed in 12 ms" in output
-    assert '"ok": true' in output
+    assert "hidden-result" not in output
     assert "Tool call:" not in output
     assert "Tool result:" not in output
 


### PR DESCRIPTION
## Summary

- render streamed command, error, and assistant output with persistent panel boundaries
- keep thinking output outside assistant panels and avoid empty panels for reasoning-only streams
- hide successful tool result payloads while preserving tool calls, timing, and error details

## Verification

- .venv/bin/pytest -q (283 passed)
- .venv/bin/mypy src
- .venv/bin/ruff check src/bub/channels/cli tests/test_channels.py tests/test_cli_renderer.py
- git diff --check HEAD