### PR TITLE
fix(logging): redact exception locals

### DIFF
--- a/src/bub/__main__.py
+++ b/src/bub/__main__.py
@@ -13,14 +13,14 @@ def _instrument_bub() -> None:
     from loguru import logger
 
     logger.remove()
-    logger.add(sys.stderr, colorize=True)
+    logger.add(sys.stderr, colorize=True, diagnose=False)
 
     try:
         import logfire
         from logfire.integrations.loguru import LogfireHandler
 
         logfire.configure()
-        logger.add(LogfireHandler(), format="{message}")
+        logger.add(LogfireHandler(), format="{message}", diagnose=False)
     except Exception as exc:
         logger.debug("logfire instrumentation disabled: {}", exc)
 

--- a/tests/test_cli_help.py
+++ b/tests/test_cli_help.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+from loguru import logger
 
 from bub.builtin.tools import show_help
 
@@ -14,3 +15,16 @@ async def test_help_lists_correct_tool_names() -> None:
 
     assert ",bash_output" not in help_text
     assert ",kill_bash" not in help_text
+
+
+def test_cli_instrumentation_disables_local_variable_diagnostics(monkeypatch: pytest.MonkeyPatch) -> None:
+    from bub.__main__ import _instrument_bub
+
+    sink_options: list[dict[str, object]] = []
+    monkeypatch.setattr(logger, "remove", lambda: None)
+    monkeypatch.setattr(logger, "add", lambda _sink, **options: sink_options.append(options))
+
+    _instrument_bub()
+
+    assert sink_options
+    assert all(options.get("diagnose") is False for options in sink_options)


### PR DESCRIPTION
## Summary

- disable Loguru local-variable diagnostics for Bub's stderr sink
- apply the same policy to the optional Logfire sink
- add a regression test requiring every Bub-owned sink to set `diagnose=False`

This preserves traceback/error reporting while preventing exception logs from rendering local secrets such as provider API keys.

Closes #292

## Verification

- `make check`
- `make test` (307 passed)
- `git diff --check`
