### PR TITLE
feat: add per-user gateway service lifecycle

### DIFF
--- a/src/bub/builtin/cli.py
+++ b/src/bub/builtin/cli.py
@@ -80,11 +80,26 @@ def list_hooks(ctx: typer.Context) -> None:
 def gateway(
     ctx: typer.Context,
     enable_channels: list[str] = typer.Option([], "--enable-channel", help="Channels to enable for CLI (default: all)"),
+    install: bool = typer.Option(False, "--install", help="Install and start the gateway as a per-user service"),
+    uninstall: bool = typer.Option(False, "--uninstall", help="Stop and uninstall the per-user gateway service"),
 ) -> None:
     """Start message listeners(like telegram)."""
-    from bub.channels.manager import ChannelManager
-
     framework = ctx.ensure_object(BubFramework)
+
+    if install and uninstall:
+        raise typer.BadParameter("--install and --uninstall cannot be used together")
+    if uninstall:
+        from bub.gateway_installer import GatewayServiceError, uninstall_gateway
+
+        try:
+            removed = uninstall_gateway()
+        except GatewayServiceError as exc:
+            typer.secho(f"Gateway uninstallation failed: {exc}", err=True, fg="red")
+            raise typer.Exit(1) from exc
+        typer.echo(f"Stopped and uninstalled the gateway from {removed.backend}: {removed.destination}")
+        return
+
+    from bub.channels.manager import ChannelManager
 
     manager = ChannelManager(framework, enabled_channels=enable_channels or None)
     if not manager.enabled_channels():
@@ -94,6 +109,16 @@ def gateway(
             fg="red",
         )
         raise typer.Exit(1)
+    if install:
+        from bub.gateway_installer import GatewayServiceError, install_gateway
+
+        try:
+            installed = install_gateway(framework.workspace, enable_channels)
+        except GatewayServiceError as exc:
+            typer.secho(f"Gateway installation failed: {exc}", err=True, fg="red")
+            raise typer.Exit(1) from exc
+        typer.echo(f"Installed and started the gateway with {installed.backend}: {installed.destination}")
+        return
     asyncio.run(manager.listen_and_run())
 
 
@@ -133,6 +158,26 @@ def onboard(ctx: typer.Context) -> None:
         raise typer.Exit(1) from exc
 
     typer.echo(f"Saved config to {framework.config_file}")
+
+    from bub import inquirer as bub_inquirer
+    from bub.gateway_installer import GatewayServiceError, install_gateway, is_gateway_service_supported
+
+    enabled_channels = str(config_data.get("enabled_channels", "")).strip()
+    if not enabled_channels or not is_gateway_service_supported():
+        return
+    if not bub_inquirer.ask_confirm("Install gateway as a background service?", default=False):
+        return
+
+    try:
+        installed = install_gateway(framework.workspace, [])
+    except GatewayServiceError as exc:
+        typer.secho(
+            f"Gateway installation failed: {exc}. Configuration remains saved at {framework.config_file}.",
+            err=True,
+            fg="red",
+        )
+        raise typer.Exit(1) from exc
+    typer.echo(f"Installed and started the gateway with {installed.backend}: {installed.destination}")
 
 
 @lru_cache(maxsize=1)

--- a/src/bub/gateway_installer.py
+++ b/src/bub/gateway_installer.py
@@ -1,0 +1,227 @@
+"""Install the Bub gateway as a per-user background service."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+SYSTEMD_UNIT_NAME = "bub-gateway.service"
+WINDOWS_TASK_NAME = "Bub Gateway"
+
+
+class GatewayServiceError(RuntimeError):
+    """Raised when the gateway service cannot be installed or removed."""
+
+
+@dataclass(frozen=True)
+class GatewayServiceResult:
+    backend: str
+    destination: str
+
+
+def is_gateway_service_supported(platform: str | None = None) -> bool:
+    """Return whether the current platform has a supported per-user service backend."""
+    platform = sys.platform if platform is None else platform
+    return platform.startswith("linux") or platform == "win32"
+
+
+def install_gateway(
+    workspace: Path,
+    enable_channels: Sequence[str],
+    *,
+    platform: str | None = None,
+    executable: Path | None = None,
+    environ: Mapping[str, str] | None = None,
+    home: Path | None = None,
+) -> GatewayServiceResult:
+    """Install and start a gateway service for the current user."""
+    platform = sys.platform if platform is None else platform
+    executable = Path(sys.executable) if executable is None else executable
+    environ = os.environ if environ is None else environ
+    home = Path.home() if home is None else home
+    workspace = workspace.resolve()
+
+    if platform.startswith("linux"):
+        return _install_systemd(workspace, enable_channels, executable, environ, home)
+    if platform == "win32":
+        return _install_windows_task(workspace, enable_channels, executable)
+    raise GatewayServiceError("Gateway installation is supported only on Linux and Windows.")
+
+
+def uninstall_gateway(
+    *,
+    platform: str | None = None,
+    environ: Mapping[str, str] | None = None,
+    home: Path | None = None,
+) -> GatewayServiceResult:
+    """Stop and uninstall the gateway service for the current user."""
+    platform = sys.platform if platform is None else platform
+    environ = os.environ if environ is None else environ
+    home = Path.home() if home is None else home
+
+    if platform.startswith("linux"):
+        return _uninstall_systemd(environ, home)
+    if platform == "win32":
+        return _uninstall_windows_task()
+    raise GatewayServiceError("Gateway uninstallation is supported only on Linux and Windows.")
+
+
+def _gateway_arguments(workspace: Path, enable_channels: Sequence[str]) -> list[str]:
+    arguments = ["-m", "bub", "--workspace", os.fspath(workspace), "gateway"]
+    for channel in enable_channels:
+        arguments.extend(["--enable-channel", channel])
+    return arguments
+
+
+def _systemd_quote(value: str) -> str:
+    escaped = (
+        value.replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+        .replace("\t", "\\t")
+        .replace("%", "%%")
+    )
+    return f'"{escaped}"'
+
+
+def _install_systemd(
+    workspace: Path,
+    enable_channels: Sequence[str],
+    executable: Path,
+    environ: Mapping[str, str],
+    home: Path,
+) -> GatewayServiceResult:
+    systemctl = shutil.which("systemctl")
+    if systemctl is None:
+        raise GatewayServiceError("systemctl was not found; a systemd user manager is required.")
+
+    unit_path = _systemd_unit_path(environ, home)
+    command = [os.fspath(executable), *_gateway_arguments(workspace, enable_channels)]
+    exec_start = " ".join(_systemd_quote(argument) for argument in command)
+    unit = f"""[Unit]
+Description=Bub gateway
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory={_systemd_quote(os.fspath(workspace))}
+ExecStart={exec_start}
+Environment=PYTHONUNBUFFERED=1
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=default.target
+"""
+
+    try:
+        unit_path.parent.mkdir(parents=True, exist_ok=True)
+        unit_path.write_text(unit, encoding="utf-8")
+        _run([systemctl, "--user", "daemon-reload"])
+        _run([systemctl, "--user", "enable", SYSTEMD_UNIT_NAME])
+        _run([systemctl, "--user", "restart", SYSTEMD_UNIT_NAME])
+    except OSError as exc:
+        raise GatewayServiceError(f"Failed to write {unit_path}: {exc}") from exc
+
+    return GatewayServiceResult(backend="systemd", destination=os.fspath(unit_path))
+
+
+def _systemd_unit_path(environ: Mapping[str, str], home: Path) -> Path:
+    config_home = Path(environ.get("XDG_CONFIG_HOME", home / ".config")).expanduser()
+    return config_home / "systemd" / "user" / SYSTEMD_UNIT_NAME
+
+
+def _uninstall_systemd(environ: Mapping[str, str], home: Path) -> GatewayServiceResult:
+    unit_path = _systemd_unit_path(environ, home)
+    if not unit_path.exists():
+        return GatewayServiceResult(backend="systemd", destination=os.fspath(unit_path))
+
+    systemctl = shutil.which("systemctl")
+    if systemctl is None:
+        raise GatewayServiceError("systemctl was not found; the systemd user unit was not removed.")
+
+    _run([systemctl, "--user", "disable", "--now", SYSTEMD_UNIT_NAME])
+    try:
+        unit_path.unlink()
+    except OSError as exc:
+        raise GatewayServiceError(f"Failed to remove {unit_path}: {exc}") from exc
+    _run([systemctl, "--user", "daemon-reload"])
+    return GatewayServiceResult(backend="systemd", destination=os.fspath(unit_path))
+
+
+def _powershell_quote(value: str) -> str:
+    return "'" + value.replace("'", "''") + "'"
+
+
+def _install_windows_task(
+    workspace: Path,
+    enable_channels: Sequence[str],
+    executable: Path,
+) -> GatewayServiceResult:
+    powershell = shutil.which("powershell.exe") or shutil.which("powershell")
+    if powershell is None:
+        raise GatewayServiceError("Windows PowerShell was not found; Task Scheduler installation is unavailable.")
+
+    arguments = subprocess.list2cmdline(_gateway_arguments(workspace, enable_channels))
+    script = "\n".join([
+        "$ErrorActionPreference = 'Stop'",
+        "$userId = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name",
+        f"Stop-ScheduledTask -TaskName {_powershell_quote(WINDOWS_TASK_NAME)} -ErrorAction SilentlyContinue",
+        (
+            "$action = New-ScheduledTaskAction "
+            f"-Execute {_powershell_quote(os.fspath(executable))} "
+            f"-Argument {_powershell_quote(arguments)} "
+            f"-WorkingDirectory {_powershell_quote(os.fspath(workspace))}"
+        ),
+        "$trigger = New-ScheduledTaskTrigger -AtLogOn -User $userId",
+        ("$principal = New-ScheduledTaskPrincipal -UserId $userId -LogonType Interactive -RunLevel Limited"),
+        (
+            "$settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries "
+            "-DontStopIfGoingOnBatteries -ExecutionTimeLimit ([TimeSpan]::Zero) "
+            "-MultipleInstances IgnoreNew -RestartCount 999 "
+            "-RestartInterval (New-TimeSpan -Minutes 1) -StartWhenAvailable"
+        ),
+        (
+            f"Register-ScheduledTask -TaskName {_powershell_quote(WINDOWS_TASK_NAME)} "
+            "-Action $action -Trigger $trigger -Principal $principal -Settings $settings "
+            "-Description 'Run the Bub gateway for the current user.' -Force | Out-Null"
+        ),
+        f"Start-ScheduledTask -TaskName {_powershell_quote(WINDOWS_TASK_NAME)}",
+    ])
+    _run([powershell, "-NoLogo", "-NoProfile", "-NonInteractive", "-Command", script])
+    return GatewayServiceResult(backend="Windows Task Scheduler", destination=WINDOWS_TASK_NAME)
+
+
+def _uninstall_windows_task() -> GatewayServiceResult:
+    powershell = shutil.which("powershell.exe") or shutil.which("powershell")
+    if powershell is None:
+        raise GatewayServiceError("Windows PowerShell was not found; Task Scheduler uninstallation is unavailable.")
+
+    task_name = _powershell_quote(WINDOWS_TASK_NAME)
+    script = "\n".join([
+        "$ErrorActionPreference = 'Stop'",
+        f"$task = Get-ScheduledTask -TaskName {task_name} -ErrorAction SilentlyContinue",
+        "if ($null -ne $task) {",
+        f"    Stop-ScheduledTask -TaskName {task_name} -ErrorAction SilentlyContinue",
+        f"    Unregister-ScheduledTask -TaskName {task_name} -Confirm:$false",
+        "}",
+    ])
+    _run([powershell, "-NoLogo", "-NoProfile", "-NonInteractive", "-Command", script])
+    return GatewayServiceResult(backend="Windows Task Scheduler", destination=WINDOWS_TASK_NAME)
+
+
+def _run(command: list[str]) -> None:
+    try:
+        subprocess.run(command, check=True, capture_output=True, text=True)
+    except FileNotFoundError as exc:
+        raise GatewayServiceError(f"Required command was not found: {command[0]}") from exc
+    except subprocess.CalledProcessError as exc:
+        detail = (exc.stderr or exc.stdout or str(exc)).strip()
+        raise GatewayServiceError(f"Command failed ({command[0]}): {detail}") from exc

--- a/tests/test_builtin_cli.py
+++ b/tests/test_builtin_cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import patch
 
@@ -149,7 +150,7 @@ def test_onboard_collects_builtin_runtime_config(tmp_path: Path, monkeypatch) ->
         monkeypatch.setattr(
             bub_inquirer,
             "ask_confirm",
-            lambda message, default=False: True,
+            lambda message, default=False: message == "Stream output",
         )
         monkeypatch.setattr(
             bub_inquirer,
@@ -174,6 +175,7 @@ def test_onboard_collects_builtin_runtime_config(tmp_path: Path, monkeypatch) ->
 def test_onboard_allows_no_channels(tmp_path: Path, monkeypatch) -> None:
     config_file = tmp_path / "config.yml"
     checkbox_validate: list[object] = []
+    confirm_messages: list[str] = []
 
     with patch.dict(os.environ, {}, clear=True):
         monkeypatch.chdir(tmp_path)
@@ -189,7 +191,12 @@ def test_onboard_allows_no_channels(tmp_path: Path, monkeypatch) -> None:
             return []
 
         monkeypatch.setattr(bub_inquirer, "ask_checkbox", ask_checkbox)
-        monkeypatch.setattr(bub_inquirer, "ask_confirm", lambda message, default=False: default)
+
+        def ask_confirm(message: str, default: bool = False) -> bool:
+            confirm_messages.append(message)
+            return default
+
+        monkeypatch.setattr(bub_inquirer, "ask_confirm", ask_confirm)
         monkeypatch.setattr(bub_inquirer, "ask_secret", lambda message: "")
 
         result = CliRunner().invoke(app, ["onboard"])
@@ -197,7 +204,68 @@ def test_onboard_allows_no_channels(tmp_path: Path, monkeypatch) -> None:
 
     assert result.exit_code == 0
     assert checkbox_validate == [None]
+    assert confirm_messages == ["Stream output"]
     assert loaded["enabled_channels"] == ""
+
+
+def test_onboard_can_install_gateway_after_saving_config(tmp_path: Path, monkeypatch) -> None:
+    config_file = tmp_path / "config.yml"
+    framework = BubFramework(config_file=config_file)
+    framework.load_hooks()
+    app = framework.create_cli_app()
+    installed = SimpleNamespace(backend="systemd", destination=os.fspath(tmp_path / "bub-gateway.service"))
+    observed: dict[str, Any] = {}
+    monkeypatch.setattr(
+        framework,
+        "collect_onboard_config",
+        lambda: {"enabled_channels": "telegram", "telegram": {"token": "token"}},
+    )
+    monkeypatch.setattr("bub.gateway_installer.is_gateway_service_supported", lambda: True)
+
+    def confirm_install(message: str, default: bool = False) -> bool:
+        assert message == "Install gateway as a background service?"
+        assert default is False
+        assert configure.load(config_file)["enabled_channels"] == "telegram"
+        return True
+
+    monkeypatch.setattr(bub_inquirer, "ask_confirm", confirm_install)
+
+    def install_gateway(workspace: Path, channels: list[str]) -> SimpleNamespace:
+        observed["workspace"] = workspace
+        observed["channels"] = channels
+        return installed
+
+    monkeypatch.setattr("bub.gateway_installer.install_gateway", install_gateway)
+
+    result = CliRunner().invoke(app, ["--workspace", os.fspath(tmp_path), "onboard"])
+
+    assert result.exit_code == 0
+    assert f"Saved config to {config_file.resolve()}" in result.output
+    assert "Installed and started the gateway with systemd" in result.output
+    assert observed == {"workspace": tmp_path.resolve(), "channels": []}
+
+
+def test_onboard_keeps_saved_config_when_gateway_installation_fails(tmp_path: Path, monkeypatch) -> None:
+    from bub.gateway_installer import GatewayServiceError
+
+    config_file = tmp_path / "config.yml"
+    framework = BubFramework(config_file=config_file)
+    framework.load_hooks()
+    app = framework.create_cli_app()
+    monkeypatch.setattr(framework, "collect_onboard_config", lambda: {"enabled_channels": "telegram"})
+    monkeypatch.setattr("bub.gateway_installer.is_gateway_service_supported", lambda: True)
+    monkeypatch.setattr(bub_inquirer, "ask_confirm", lambda message, default=False: True)
+
+    def fail_install(workspace: Path, channels: list[str]) -> None:
+        raise GatewayServiceError("user service unavailable")
+
+    monkeypatch.setattr("bub.gateway_installer.install_gateway", fail_install)
+
+    result = CliRunner().invoke(app, ["onboard"])
+
+    assert result.exit_code == 1
+    assert "Configuration remains saved" in result.output
+    assert configure.load(config_file)["enabled_channels"] == "telegram"
 
 
 def test_onboard_aborts_immediately_when_builtin_prompt_is_interrupted(tmp_path: Path, monkeypatch) -> None:
@@ -275,6 +343,54 @@ def test_gateway_fails_when_no_channels_are_enabled(tmp_path: Path, monkeypatch)
 
     assert result.exit_code == 1
     assert "No channels are enabled." in result.output
+
+
+def test_gateway_install_uses_current_workspace_and_channels(tmp_path: Path, monkeypatch) -> None:
+    config_file = tmp_path / "config.yml"
+    configure.save(config_file, {"enabled_channels": "telegram", "telegram": {"token": "token"}})
+    framework = BubFramework(config_file=config_file)
+    framework.load_hooks()
+    app = framework.create_cli_app()
+    installed = SimpleNamespace(backend="systemd", destination=os.fspath(tmp_path / "bub-gateway.service"))
+    observed: dict[str, Any] = {}
+
+    def install_gateway(workspace: Path, channels: list[str]) -> SimpleNamespace:
+        observed["workspace"] = workspace
+        observed["channels"] = channels
+        return installed
+
+    monkeypatch.setattr("bub.gateway_installer.install_gateway", install_gateway)
+
+    result = CliRunner().invoke(
+        app,
+        ["--workspace", os.fspath(tmp_path), "gateway", "--install", "--enable-channel", "telegram"],
+    )
+
+    assert result.exit_code == 0
+    assert "Installed and started the gateway with systemd" in result.output
+    assert observed == {"workspace": tmp_path.resolve(), "channels": ["telegram"]}
+
+
+def test_gateway_uninstall_does_not_require_enabled_channels(tmp_path: Path, monkeypatch) -> None:
+    config_file = tmp_path / "config.yml"
+    configure.save(config_file, {"enabled_channels": ""})
+    framework = BubFramework(config_file=config_file)
+    framework.load_hooks()
+    app = framework.create_cli_app()
+    removed = SimpleNamespace(backend="systemd", destination=os.fspath(tmp_path / "bub-gateway.service"))
+    monkeypatch.setattr("bub.gateway_installer.uninstall_gateway", lambda: removed)
+
+    result = CliRunner().invoke(app, ["gateway", "--uninstall"])
+
+    assert result.exit_code == 0
+    assert "Stopped and uninstalled the gateway from systemd" in result.output
+
+
+def test_gateway_install_and_uninstall_are_mutually_exclusive() -> None:
+    result = CliRunner().invoke(_create_app(), ["gateway", "--install", "--uninstall"])
+
+    assert result.exit_code == 2
+    assert "cannot be used together" in result.output
 
 
 def test_run_command_processes_inbound_inside_framework_runtime(tmp_path: Path) -> None:

--- a/tests/test_framework.py
+++ b/tests/test_framework.py
@@ -225,6 +225,8 @@ def test_builtin_cli_exposes_gateway_command(write_config) -> None:
     assert gateway_result.exit_code == 0
     assert "bub gateway" in gateway_result.stdout
     assert "Start message listeners" in gateway_result.stdout
+    assert "--install" in gateway_result.stdout
+    assert "--uninstall" in gateway_result.stdout
 
 
 def test_load_hooks_loads_root_and_named_config_sections(monkeypatch: pytest.MonkeyPatch, write_config) -> None:

--- a/tests/test_gateway_installer.py
+++ b/tests/test_gateway_installer.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from bub.gateway_installer import (
+    GatewayServiceError,
+    install_gateway,
+    is_gateway_service_supported,
+    uninstall_gateway,
+)
+
+
+@pytest.mark.parametrize(
+    ("platform", "expected"), [("linux", True), ("linux2", True), ("win32", True), ("darwin", False)]
+)
+def test_is_gateway_service_supported(platform: str, expected: bool) -> None:
+    assert is_gateway_service_supported(platform) is expected
+
+
+def test_install_gateway_writes_and_enables_systemd_user_unit(tmp_path: Path, monkeypatch) -> None:
+    workspace = tmp_path / "project with spaces"
+    workspace.mkdir()
+    config_home = tmp_path / "config"
+    commands: list[list[str]] = []
+    monkeypatch.setattr("bub.gateway_installer.shutil.which", lambda command: "/usr/bin/systemctl")
+    monkeypatch.setattr(
+        "bub.gateway_installer.subprocess.run",
+        lambda command, **kwargs: commands.append(command),
+    )
+
+    result = install_gateway(
+        workspace,
+        ["telegram", "!cron"],
+        platform="linux",
+        executable=Path("/opt/bub venv/bin/python"),
+        environ={"XDG_CONFIG_HOME": os.fspath(config_home)},
+        home=tmp_path,
+    )
+
+    unit_path = config_home / "systemd" / "user" / "bub-gateway.service"
+    unit = unit_path.read_text(encoding="utf-8")
+
+    assert result.backend == "systemd"
+    assert result.destination == os.fspath(unit_path)
+    assert f'WorkingDirectory="{workspace}"' in unit
+    assert 'ExecStart="/opt/bub venv/bin/python" "-m" "bub"' in unit
+    assert '"--enable-channel" "telegram" "--enable-channel" "!cron"' in unit
+    assert "WantedBy=default.target" in unit
+    assert commands == [
+        ["/usr/bin/systemctl", "--user", "daemon-reload"],
+        ["/usr/bin/systemctl", "--user", "enable", "bub-gateway.service"],
+        ["/usr/bin/systemctl", "--user", "restart", "bub-gateway.service"],
+    ]
+
+
+def test_install_gateway_registers_current_user_windows_task(tmp_path: Path, monkeypatch) -> None:
+    workspace = tmp_path / "project's workspace"
+    workspace.mkdir()
+    commands: list[tuple[list[str], dict]] = []
+    monkeypatch.setattr("bub.gateway_installer.shutil.which", lambda command: r"C:\Windows\powershell.exe")
+    monkeypatch.setattr(
+        "bub.gateway_installer.subprocess.run",
+        lambda command, **kwargs: commands.append((command, kwargs)),
+    )
+
+    result = install_gateway(
+        workspace,
+        ["telegram"],
+        platform="win32",
+        executable=Path(r"C:\Users\Frost\bub venv\python.exe"),
+    )
+
+    assert result.backend == "Windows Task Scheduler"
+    assert result.destination == "Bub Gateway"
+    assert len(commands) == 1
+    command, kwargs = commands[0]
+    script = command[-1]
+    assert command[:4] == [r"C:\Windows\powershell.exe", "-NoLogo", "-NoProfile", "-NonInteractive"]
+    assert "New-ScheduledTaskTrigger -AtLogOn -User $userId" in script
+    assert "-LogonType Interactive -RunLevel Limited" in script
+    assert "-RestartCount 999" in script
+    assert "Stop-ScheduledTask -TaskName 'Bub Gateway'" in script
+    assert "Register-ScheduledTask -TaskName 'Bub Gateway'" in script
+    assert "Start-ScheduledTask -TaskName 'Bub Gateway'" in script
+    assert "project''s workspace" in script
+    assert kwargs == {"check": True, "capture_output": True, "text": True}
+
+
+def test_install_gateway_rejects_unsupported_platform(tmp_path: Path) -> None:
+    with pytest.raises(GatewayServiceError, match="supported only on Linux and Windows"):
+        install_gateway(tmp_path, [], platform="darwin")
+
+
+def test_install_gateway_reports_activation_failure(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr("bub.gateway_installer.shutil.which", lambda command: "/usr/bin/systemctl")
+
+    def fail(command: list[str], **kwargs) -> None:
+        raise subprocess.CalledProcessError(1, command, stderr="user bus unavailable")
+
+    monkeypatch.setattr("bub.gateway_installer.subprocess.run", fail)
+
+    with pytest.raises(GatewayServiceError, match="user bus unavailable"):
+        install_gateway(tmp_path, [], platform="linux", environ={}, home=tmp_path)
+
+
+def test_uninstall_gateway_disables_and_removes_systemd_user_unit(tmp_path: Path, monkeypatch) -> None:
+    unit_path = tmp_path / ".config" / "systemd" / "user" / "bub-gateway.service"
+    unit_path.parent.mkdir(parents=True)
+    unit_path.write_text("[Unit]\n", encoding="utf-8")
+    commands: list[list[str]] = []
+    monkeypatch.setattr("bub.gateway_installer.shutil.which", lambda command: "/usr/bin/systemctl")
+    monkeypatch.setattr(
+        "bub.gateway_installer.subprocess.run",
+        lambda command, **kwargs: commands.append(command),
+    )
+
+    result = uninstall_gateway(platform="linux", environ={}, home=tmp_path)
+
+    assert result.backend == "systemd"
+    assert result.destination == os.fspath(unit_path)
+    assert not unit_path.exists()
+    assert commands == [
+        ["/usr/bin/systemctl", "--user", "disable", "--now", "bub-gateway.service"],
+        ["/usr/bin/systemctl", "--user", "daemon-reload"],
+    ]
+
+
+def test_uninstall_gateway_is_idempotent_when_systemd_unit_is_absent(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "bub.gateway_installer.shutil.which",
+        lambda command: pytest.fail("systemctl should not be required when the unit is absent"),
+    )
+
+    result = uninstall_gateway(platform="linux", environ={}, home=tmp_path)
+
+    assert result.backend == "systemd"
+    assert not Path(result.destination).exists()
+
+
+def test_uninstall_gateway_stops_and_unregisters_windows_task(monkeypatch) -> None:
+    commands: list[list[str]] = []
+    monkeypatch.setattr("bub.gateway_installer.shutil.which", lambda command: r"C:\Windows\powershell.exe")
+    monkeypatch.setattr(
+        "bub.gateway_installer.subprocess.run",
+        lambda command, **kwargs: commands.append(command),
+    )
+
+    result = uninstall_gateway(platform="win32")
+
+    assert result.backend == "Windows Task Scheduler"
+    assert len(commands) == 1
+    script = commands[0][-1]
+    assert "Get-ScheduledTask -TaskName 'Bub Gateway'" in script
+    assert "Stop-ScheduledTask -TaskName 'Bub Gateway'" in script
+    assert "Unregister-ScheduledTask -TaskName 'Bub Gateway' -Confirm:$false" in script

--- a/website/src/content/docs/docs/reference/cli.mdx
+++ b/website/src/content/docs/docs/reference/cli.mdx
@@ -70,12 +70,19 @@ bub gateway [OPTIONS]
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
 | `--enable-channel` | TEXT (repeatable) | empty list (use `BUB_ENABLED_CHANNELS`) | Restrict gateway to the listed channel names. Pass multiple times. |
+| `--install` | flag | disabled | Install and start the gateway as a per-user background service. |
+| `--uninstall` | flag | disabled | Stop and uninstall the per-user gateway service. |
 
 Behavior notes:
 
 - When `--enable-channel` is omitted the manager reads `ChannelSettings.enabled_channels` (`BUB_ENABLED_CHANNELS`, default `all`).
 - `all` starts every enabled non-`Interface` channel. When you list at least one non-`Lifecycle` channel explicitly, enabled `Lifecycle` runtimes are attached automatically. Use `!name` to exclude one.
 - `framework.running()` is held open until the manager loop exits; `provide_tape_store` cleanup runs on shutdown.
+- On Linux, `--install` writes `bub-gateway.service` under `${XDG_CONFIG_HOME:-~/.config}/systemd/user/`, enables it for the user's default target, and starts or restarts it. Use `loginctl enable-linger` separately if it must remain active after logout.
+- On Windows, `--install` registers and starts a current-user `Bub Gateway` Task Scheduler task. It runs at that user's logon with limited privileges and restarts after failures.
+- Installation captures the current Python executable, workspace, and explicit `--enable-channel` values. Re-running the command replaces and restarts the existing service; do so after moving or replacing the Python environment.
+- `--uninstall` stops and removes the corresponding systemd user unit or Windows scheduled task. It succeeds when the service is already absent and does not require an enabled channel.
+- `--install` and `--uninstall` are mutually exclusive.
 
 See [Operate › Channels](/docs/operate/channels/) for per-channel deployment notes.
 
@@ -96,13 +103,14 @@ Behavior notes:
 - The builtin onboarding fragment prompts for: provider (one of `openrouter`, `openai`, `anthropic`, `gemini`, `azure`, `bedrock`, `ollama`, `groq`, `mistral`, `deepseek`, plus `custom`), model name, optional API key, optional API base, enabled channels, and stream output.
 - Each plugin's `onboard_config` hook receives the accumulated dict so far; non-dict returns abort with `TypeError`.
 - The merged dict is validated through `configure.validate` before being written.
+- After saving a configuration with at least one channel on Linux or Windows, onboarding asks whether to install the gateway as a per-user background service. The default is no. Installation failure leaves the saved configuration intact and exits with code `1`.
 
 Exit codes:
 
 | Code | Meaning |
 | --- | --- |
 | `0` | Config saved. |
-| `1` | Validation or write error; message printed to stderr. |
+| `1` | Validation, write, or requested gateway installation error; message printed to stderr. |
 
 ## `bub install`
 

--- a/website/src/content/docs/zh-cn/docs/reference/cli.mdx
+++ b/website/src/content/docs/zh-cn/docs/reference/cli.mdx
@@ -70,12 +70,19 @@ bub gateway [OPTIONS]
 | 选项 | 类型 | 默认值 | 描述 |
 | --- | --- | --- | --- |
 | `--enable-channel` | TEXT (repeatable) | 空列表(读取 `BUB_ENABLED_CHANNELS`) | 限制 gateway 仅启用列出的 channel 名。可重复传入。 |
+| `--install` | flag | 关闭 | 把 gateway 安装并启动为当前用户的后台服务。 |
+| `--uninstall` | flag | 关闭 | 停止并卸载当前用户的 gateway 后台服务。 |
 
 行为说明:
 
 - 未传 `--enable-channel` 时,Manager 读取 `ChannelSettings.enabled_channels`(`BUB_ENABLED_CHANNELS`,默认 `all`)。
 - `all` 会启动所有已启用且不是 `Interface` 的 channel。显式列出且至少包含一个非 `Lifecycle` channel 时，会自动附着已启用的 `Lifecycle` 后台服务；可用 `!name` 排除其中某个 channel。
 - `framework.running()` 持续到 manager 主循环退出;关闭时执行 `provide_tape_store` 的清理。
+- Linux 上，`--install` 会把 `bub-gateway.service` 写入 `${XDG_CONFIG_HOME:-~/.config}/systemd/user/`，为用户的 default target 启用它，并启动或重启服务；如需在退出登录后继续运行，需另行执行 `loginctl enable-linger`。
+- Windows 上，`--install` 会注册并启动当前用户的 `Bub Gateway` Task Scheduler 任务。任务在该用户登录时以有限权限运行，并在失败后重启。
+- 安装会固化当前 Python 解释器、workspace 与显式传入的 `--enable-channel`。重复执行会替换并重启现有服务；移动或替换 Python 环境后应重新执行安装命令。
+- `--uninstall` 会停止并删除对应的 systemd user unit 或 Windows 计划任务。服务已经不存在时仍视为成功，且不要求当前存在已启用的 channel。
+- `--install` 与 `--uninstall` 不能同时使用。
 
 部署细节见 [运维 › Channels](/zh-cn/docs/operate/channels/)。
 
@@ -96,13 +103,14 @@ bub onboard [OPTIONS]
 - builtin 的 onboarding fragment 会询问:provider(`openrouter`、`openai`、`anthropic`、`gemini`、`azure`、`bedrock`、`ollama`、`groq`、`mistral`、`deepseek` 之一,或 `custom`)、模型名、可选 API key、可选 API base、启用的 channel、是否流式输出。
 - 每个插件的 `onboard_config` 钩子都会拿到当前已累计的 dict;返回值不是 dict 时抛 `TypeError` 并中止。
 - 合并后的 dict 会经过 `configure.validate` 验证后才写入。
+- Linux 或 Windows 上保存了至少一个 channel 后，onboarding 会询问是否把 gateway 安装为当前用户的后台服务，默认选择否。安装失败不会回滚已保存的配置，并以退出码 `1` 结束。
 
 退出码:
 
 | 退出码 | 含义 |
 | --- | --- |
 | `0` | 配置已保存。 |
-| `1` | 验证或写入失败;错误信息打印到 stderr。 |
+| `1` | 验证、写入或用户请求的 gateway 安装失败;错误信息打印到 stderr。 |
 
 ## `bub install`
 


### PR DESCRIPTION
## Summary

- add `bub gateway --install` and `--uninstall` for per-user background services
- install a systemd user service on Linux and a current-user Task Scheduler task on Windows
- make reinstall replace and restart the existing service, while uninstall remains idempotent
- offer optional gateway installation after `bub onboard` saves a valid channel configuration
- document the lifecycle behavior in the English and Chinese CLI references

## Platform behavior

- Linux writes `bub-gateway.service` to the XDG systemd user directory and enables/restarts it through `systemctl --user`
- Windows uses built-in ScheduledTasks PowerShell cmdlets with a limited interactive principal, at-logon trigger, working directory, and restart policy
- service definitions retain the active Python executable and workspace without copying API keys or other secret environment variables
- onboarding defaults the installation prompt to no and preserves the saved configuration if installation fails

## Verification commands

- `uv run ruff check src/bub/gateway_installer.py src/bub/builtin/cli.py tests/test_gateway_installer.py tests/test_builtin_cli.py tests/test_framework.py`
- `uv run mypy src`
- `uv run pytest -q`
- `BUB_ASTRO_IMAGE_MODE=build node_modules/.bin/astro build` from `website/`

## Follow-up validation

- smoke-test install, restart/login behavior, reinstall, and uninstall on representative systemd Linux and Windows hosts
- enable systemd lingering separately when a deployment must survive logout
