### PR TITLE
fix: link verbosity to logging level

### DIFF
--- a/src/bub/__main__.py
+++ b/src/bub/__main__.py
@@ -6,28 +6,35 @@ import sys
 
 import typer
 
+from bub.builtin.settings import load_settings
 from bub.framework import BubFramework
 
+LOG_LEVEL = {
+    0: "INFO",
+    1: "DEBUG",
+    2: "TRACE",
+}
 
-def _instrument_bub() -> None:
+
+def _instrument_bub(level: str) -> None:
     from loguru import logger
 
     logger.remove()
-    logger.add(sys.stderr, colorize=True, diagnose=False)
+    logger.add(sys.stderr, level=level, colorize=True, diagnose=False)
 
     try:
         import logfire
         from logfire.integrations.loguru import LogfireHandler
 
         logfire.configure()
-        logger.add(LogfireHandler(), format="{message}", diagnose=False)
+        logger.add(LogfireHandler(), level=level, format="{message}", diagnose=False)
     except Exception as exc:
         logger.debug("logfire instrumentation disabled: {}", exc)
 
 
 def create_cli_app() -> typer.Typer:
-    _instrument_bub()
     framework = BubFramework()
+    _instrument_bub(LOG_LEVEL[load_settings().verbose])
     framework.load_hooks()
     app = framework.create_cli_app()
 

--- a/tests/test_cli_help.py
+++ b/tests/test_cli_help.py
@@ -24,7 +24,7 @@ def test_cli_instrumentation_disables_local_variable_diagnostics(monkeypatch: py
     monkeypatch.setattr(logger, "remove", lambda: None)
     monkeypatch.setattr(logger, "add", lambda _sink, **options: sink_options.append(options))
 
-    _instrument_bub()
+    _instrument_bub(level="INFO")
 
     assert sink_options
     assert all(options.get("diagnose") is False for options in sink_options)


### PR DESCRIPTION
## Summary

- map `BUB_VERBOSE` values to Loguru levels: `0` → `INFO`, `1` → `DEBUG`, and `2` → `TRACE`
- configure both the stderr and optional Logfire sinks with the selected level
- load settings after `BubFramework` loads the YAML configuration, so file and environment settings are respected

## Why

Loguru defaults new sinks to `DEBUG`, which made Bub print the optional Logfire import diagnostic during normal CLI startup. The existing `verbose` setting was not connected to logging.

## Verification

- `make check`
- `uv run pytest -q tests/test_cli_help.py tests/test_settings.py` (14 passed)
- `make test` (330 passed, 1 skipped, 4 unrelated existing failures in `tests/test_install_scripts.py` because `website/public/install.sh` expands an unset `EXTRA_DEPENDENCIES` array under macOS `/bin/bash`)
- tox not run locally; the contribution guide notes that CI runs the Python version matrix